### PR TITLE
Fixes the duplicate css

### DIFF
--- a/src/sugar4/graphics/__init__.py
+++ b/src/sugar4/graphics/__init__.py
@@ -20,6 +20,15 @@ except ImportError:
     # gi might not be available during docs build
     pass
 
+# Initialize Sugar theme system
+# This loads CSS from sugar-artwork if available, or uses bundled fallback
+try:
+    from .theme import init_sugar_themes
+    init_sugar_themes()
+except Exception:
+    # Continue even if theme initialization fails
+    pass
+
 from .xocolor import XoColor
 from .icon import (
     Icon,

--- a/src/sugar4/graphics/menuitem.py
+++ b/src/sugar4/graphics/menuitem.py
@@ -113,22 +113,12 @@ class MenuItem(Gtk.Button):
         self.connect("unmap", self._on_unmapped)
 
     def _apply_menu_item_styling(self):
-        """Apply CSS styling to make button look like a menu item."""
-        css = """
-        button.menuitem {
-            background: transparent;
-            border: none;
-            border-radius: 4px;
-            padding: 4px 6px;
-        }
-        button.menuitem:hover {
-            background: alpha(@theme_selected_bg_color, 0.1);
-        }
-        button.menuitem:active {
-            background: alpha(@theme_selected_bg_color, 0.2);
-        }
+        """Apply CSS styling for menu items using centralized theme.
+        
+        CSS is defined in sugar-gtk4.css (.menuitem class) or sugar-artwork
+        themes to avoid duplication and maintain Sugar design consistency.
         """
-        style.apply_css_to_widget(self, css)
+        # CSS styling is managed by the centralized theme loader
 
     def _on_mapped(self, widget):
         """Handle widget being mapped (shown)."""
@@ -256,12 +246,9 @@ class MenuSeparator(Gtk.Separator):
         self._apply_separator_styling()
 
     def _apply_separator_styling(self):
-        """Apply styling for menu separator."""
-        css = """
-        separator.menu-separator {
-            margin: 2px 6px;
-            min-height: 1px;
-            background: alpha(@theme_fg_color, 0.2);
-        }
+        """Apply styling for menu separator using centralized theme.
+        
+        CSS is defined in sugar-gtk4.css (.menu-separator class) or 
+        sugar-artwork themes to avoid duplication.
         """
-        style.apply_css_to_widget(self, css)
+        # CSS styling is managed by the centralized theme loader

--- a/src/sugar4/graphics/palettemenu.py
+++ b/src/sugar4/graphics/palettemenu.py
@@ -183,21 +183,14 @@ class PaletteMenuItemSeparator(Gtk.Separator):
         self.set_size_request(-1, style.DEFAULT_SPACING * 2)
 
         self.add_css_class("palette-menu-separator")
-        self._apply_separator_styling()
 
     def _apply_separator_styling(self):
-        """Apply CSS styling for the separator."""
-        css = """
-        separator.palette-menu-separator {
-            margin: 2px 6px;
-            min-height: 1px;
-            background: alpha(@theme_fg_color, 0.2);
-        }
+        """Apply CSS styling for the separator using centralized theme.
+        
+        CSS is defined in sugar-gtk4.css or sugar-artwork themes to avoid
+        duplication and maintain consistency with Sugar design.
         """
-        try:
-            style.apply_css_to_widget(self, css)
-        except Exception as e:
-            logging.warning(f"Could not apply separator CSS: {e}")
+        # CSS styling is managed by the centralized theme loader
 
 
 class PaletteMenuItem(Gtk.Button):
@@ -305,28 +298,12 @@ class PaletteMenuItem(Gtk.Button):
         self.emit("item-activated")
 
     def _apply_menu_item_styling(self):
-        """Apply CSS styling to make button look like a menu item."""
-        css = """
-        button.palette-menu-item {
-            background: transparent;
-            border: none;
-            border-radius: 4px;
-            padding: 0;
-        }
-        button.palette-menu-item:hover {
-            background: alpha(@theme_selected_bg_color, 0.1);
-        }
-        button.palette-menu-item:active {
-            background: alpha(@theme_selected_bg_color, 0.2);
-        }
-        button.palette-menu-item:disabled {
-            opacity: 0.5;
-        }
+        """Apply CSS styling for palette menu items using centralized theme.
+        
+        CSS is defined in sugar-gtk4.css (.palette-menu-item class) or 
+        sugar-artwork themes to avoid duplication and maintain consistency.
         """
-        try:
-            style.apply_css_to_widget(self, css)
-        except Exception as e:
-            logging.warning(f"Could not apply menu item CSS: {e}")
+        # CSS styling is managed by the centralized theme loader
 
     def _setup_gestures(self):
         """Set up gesture controllers for hover effects."""

--- a/src/sugar4/graphics/radiotoolbutton.py
+++ b/src/sugar4/graphics/radiotoolbutton.py
@@ -82,26 +82,14 @@ class RadioToolButton(ToolButton):
 
         # radio button styling
         self.add_css_class("radio-tool-button")
-        self._apply_radio_styling()
 
     def _apply_radio_styling(self):
-        css = """
-        .radio-tool-button {
-            border-radius: 4px;
-            margin: 1px;
-        }
+        """Apply radio button styling using centralized theme.
         
-        .radio-tool-button:checked,
-        .radio-tool-button.active {
-            background: alpha(@theme_selected_bg_color, 0.2);
-            border: 1px solid @theme_selected_bg_color;
-        }
-        
-        .radio-tool-button:hover:not(.active) {
-            background: alpha(@theme_fg_color, 0.05);
-        }
+        CSS is defined in sugar-gtk4.css (.radio-tool-button class) or
+        sugar-artwork themes to avoid duplication.
         """
-        style.apply_css_to_widget(self, css)
+        # CSS styling is managed by the centralized theme loader
 
     def _on_clicked(self, button):
         """Handle button click."""

--- a/src/sugar4/graphics/sugar-gtk4.css
+++ b/src/sugar4/graphics/sugar-gtk4.css
@@ -1,0 +1,267 @@
+/*
+ * Sugar Toolkit GTK4 Theme CSS
+ * 
+ * This file contains all Sugar-specific CSS styling for GTK4 widgets.
+ * It centralizes styling that should be consistent with sugar-artwork.
+ * 
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+/* ============================================================================
+ * Toolbar and ToolbarBox Styling
+ * ============================================================================ */
+
+/* Main toolbar box container */
+.sugar-toolbarbox {
+    background: #282828;
+    padding: 0;
+    margin: 0;
+}
+
+/* Expandable toolbar buttons */
+.toolbar-expandable-button {
+    margin: 2px;
+    border-radius: 4px;
+    padding: 2px;
+}
+
+.toolbar-expandable-button:hover {
+    background: alpha(@theme_fg_color, 0.1);
+}
+
+.toolbar-expandable-button:active {
+    background: alpha(@theme_fg_color, 0.2);
+}
+
+.toolbar-expandable-button.expanded {
+    background: alpha(@theme_selected_bg_color, 0.2);
+    border-bottom: 2px solid @theme_selected_bg_color;
+}
+
+/* Regular toolbar buttons */
+.toolbar-button {
+    border-radius: 6px;
+    margin: 2px;
+    padding: 6px;
+    min-width: 32px;
+    min-height: 32px;
+}
+
+.toolbar-button:hover {
+    background: alpha(@theme_fg_color, 0.1);
+}
+
+.toolbar-button:active,
+.toolbar-button.active {
+    background: alpha(@theme_fg_color, 0.2);
+    border: 1px solid alpha(@theme_fg_color, 0.3);
+}
+
+.toolbar-button:focus {
+    outline: 2px solid @theme_selected_bg_color;
+    outline-offset: 2px;
+}
+
+.toolbar-button icon {
+    min-width: 24px;
+    min-height: 24px;
+}
+
+.toolbar-button label {
+    font-size: 0.9em;
+}
+
+/* Ensure proper spacing in horizontal toolbars */
+toolbar .toolbar-button {
+    margin: 1px;
+}
+
+/* Active palette indicator */
+.toolbar-button.active {
+    box-shadow: inset 0 0 0 2px @theme_selected_bg_color;
+}
+
+/* ============================================================================
+ * Toolbox Styling (Tabbed Interface)
+ * ============================================================================ */
+
+notebook.toolbox {
+    background: #282828;
+}
+
+notebook.toolbox > header {
+    background: #282828;
+    padding: 4px 2px;
+}
+
+notebook.toolbox > header > tabs > tab {
+    background: transparent;
+    border: none;
+    padding: 4px 2px;
+    min-width: 150px;
+}
+
+notebook.toolbox > header > tabs > tab:checked {
+    background: alpha(@theme_selected_bg_color, 0.1);
+}
+
+separator.toolbox-separator {
+    background: #c0c0c0;
+    min-height: 1px;
+}
+
+/* ============================================================================
+ * Palette Menu Styling
+ * ============================================================================ */
+
+.palette {
+    background: #282828;
+    border: 1px solid #a6a6a6;
+}
+
+.palette-action-bar {
+    background: #282828;
+    padding: 6px;
+}
+
+.palette-action-bar button {
+    margin: 2px;
+}
+
+.palette-menu-item {
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    padding: 0;
+}
+
+.palette-menu-item:hover {
+    background: alpha(@theme_selected_bg_color, 0.1);
+}
+
+.palette-menu-item:active {
+    background: alpha(@theme_selected_bg_color, 0.2);
+}
+
+.palette-menu-item:disabled {
+    opacity: 0.5;
+}
+
+separator.palette-menu-separator {
+    margin: 2px 6px;
+    min-height: 1px;
+    background: alpha(@theme_fg_color, 0.2);
+}
+
+/* ============================================================================
+ * Menu Item Styling
+ * ============================================================================ */
+
+.menuitem {
+    border-radius: 4px;
+    padding: 6px 8px;
+    margin: 1px;
+}
+
+.menuitem:hover {
+    background: alpha(@theme_selected_bg_color, 0.15);
+}
+
+.menuitem:active {
+    background: alpha(@theme_selected_bg_color, 0.25);
+}
+
+.menuitem label {
+    padding: 0 6px;
+}
+
+.menu-separator {
+    min-height: 1px;
+    background: #a6a6a6;
+    margin: 4px 0;
+}
+
+.force-black {
+    color: #000000;
+}
+
+/* ============================================================================
+ * Radio Toolbar Button Styling
+ * ============================================================================ */
+
+.radio-tool-button {
+    border-radius: 6px;
+    margin: 2px;
+    padding: 6px;
+    min-width: 32px;
+    min-height: 32px;
+}
+
+.radio-tool-button:hover {
+    background: alpha(@theme_fg_color, 0.1);
+}
+
+.radio-tool-button:active,
+.radio-tool-button.active {
+    background: alpha(@theme_selected_bg_color, 0.3);
+    border: 1px solid @theme_selected_bg_color;
+}
+
+.radio-tool-button:checked {
+    background: alpha(@theme_selected_bg_color, 0.3);
+    border: 1px solid @theme_selected_bg_color;
+}
+
+/* ============================================================================
+ * Alert Dialog Styling
+ * ============================================================================ */
+
+.sugar-alert {
+    background: white;
+    border-radius: 8px;
+    padding: 12px;
+}
+
+.sugar-alert label {
+    color: #000000;
+}
+
+/* ============================================================================
+ * Tray Styling (HTray, VTray)
+ * ============================================================================ */
+
+htray {
+    background: transparent;
+}
+
+vtray {
+    background: transparent;
+}
+
+.drag-active {
+    background: alpha(@theme_selected_bg_color, 0.2);
+}
+
+/* ============================================================================
+ * Window Styling
+ * ============================================================================ */
+
+.unfullscreen-button {
+    margin: 2px;
+}
+
+/* ============================================================================
+ * General Widget Styling
+ * ============================================================================ */
+
+/* Ensure consistent spacing */
+.sugar-widget {
+    margin: 0;
+    padding: 0;
+}
+
+/* Additional toolbar styling for consistency */
+.toolbar {
+    background: #282828;
+    padding: 2px;
+}

--- a/src/sugar4/graphics/theme.py
+++ b/src/sugar4/graphics/theme.py
@@ -1,0 +1,210 @@
+"""
+CSS Theme Loader for Sugar Toolkit GTK4
+
+This module provides centralized CSS theme loading from sugar-artwork
+and fallback CSS definitions for Sugar toolkit components.
+
+SPDX-License-Identifier: LGPL-2.1-or-later
+"""
+
+import os
+import gi
+from typing import Optional
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class SugarThemeLoader:
+    """
+    Loads CSS themes from sugar-artwork or uses fallback definitions.
+    
+    This class manages the loading and application of Sugar-specific CSS
+    styling, preferring sugar-artwork themes when available.
+    """
+
+    _instance = None
+    _css_provider = None
+    _fallback_css_loaded = False
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    @classmethod
+    def get_instance(cls):
+        """Get the singleton instance of SugarThemeLoader."""
+        return cls()
+
+    def __init__(self):
+        """Initialize the theme loader."""
+        self.css_provider = Gtk.CssProvider()
+        self._sugar_artwork_path = None
+        self._find_sugar_artwork()
+
+    def _find_sugar_artwork(self) -> Optional[str]:
+        """
+        Find the sugar-artwork installation path.
+        
+        Returns:
+            Path to sugar-artwork CSS files, or None if not found.
+        """
+        # Common installation paths for sugar-artwork
+        possible_paths = [
+            "/usr/share/sugar/artwork",
+            "/usr/local/share/sugar/artwork",
+            "/opt/sugar/artwork",
+            os.path.expanduser("~/.local/share/sugar/artwork"),
+        ]
+
+        for path in possible_paths:
+            if os.path.exists(path):
+                logger.info(f"Found sugar-artwork at: {path}")
+                self._sugar_artwork_path = path
+                return path
+
+        logger.debug("sugar-artwork not found in common paths")
+        return None
+
+    def load_theme(self, theme_name: str = "default") -> bool:
+        """
+        Load a theme from sugar-artwork.
+        
+        Args:
+            theme_name: Name of the theme to load (without extension).
+                       Defaults to "default".
+        
+        Returns:
+            True if theme was loaded successfully, False otherwise.
+        """
+        if self._sugar_artwork_path is None:
+            logger.warning("sugar-artwork not found, using fallback CSS")
+            return self.load_fallback_css()
+
+        css_path = os.path.join(
+            self._sugar_artwork_path, f"themes/{theme_name}.css"
+        )
+
+        if not os.path.exists(css_path):
+            logger.warning(
+                f"Theme file not found: {css_path}, trying alternate paths"
+            )
+            # Try alternate path structure
+            css_path = os.path.join(
+                self._sugar_artwork_path, f"{theme_name}.css"
+            )
+
+        if not os.path.exists(css_path):
+            logger.warning(f"Theme file not found at any location, using fallback")
+            return self.load_fallback_css()
+
+        try:
+            self.css_provider.load_from_path(css_path)
+            self._apply_css_provider()
+            logger.info(f"Loaded theme from sugar-artwork: {css_path}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to load theme from {css_path}: {e}")
+            return self.load_fallback_css()
+
+    def load_fallback_css(self) -> bool:
+        """
+        Load fallback CSS from sugar-toolkit-gtk4.
+        
+        Returns:
+            True if fallback CSS was loaded successfully, False otherwise.
+        """
+        if self._fallback_css_loaded:
+            return True
+
+        # Get the path to the fallback CSS file
+        current_dir = os.path.dirname(__file__)
+        css_path = os.path.join(current_dir, "sugar-gtk4.css")
+
+        if not os.path.exists(css_path):
+            logger.error(f"Fallback CSS file not found: {css_path}")
+            return False
+
+        try:
+            self.css_provider.load_from_path(css_path)
+            self._apply_css_provider()
+            self._fallback_css_loaded = True
+            logger.info(f"Loaded fallback CSS from: {css_path}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to load fallback CSS from {css_path}: {e}")
+            return False
+
+    def load_css_string(self, css: str) -> bool:
+        """
+        Load CSS from a string.
+        
+        Args:
+            css: CSS string to load.
+        
+        Returns:
+            True if CSS was loaded successfully, False otherwise.
+        """
+        try:
+            self.css_provider.load_from_data(css.encode())
+            self._apply_css_provider()
+            return True
+        except Exception as e:
+            logger.error(f"Failed to load CSS from string: {e}")
+            return False
+
+    def _apply_css_provider(self):
+        """Apply the CSS provider to the default display."""
+        try:
+            display = Gtk.SettingsList().get_default_display()
+            if display:
+                Gtk.StyleContext.add_provider_for_display(display, self.css_provider, 600)
+            else:
+                logger.warning("Could not get default display for CSS provider")
+        except Exception as e:
+            logger.error(f"Failed to apply CSS provider: {e}")
+
+    @staticmethod
+    def apply_css_to_widget(widget, css: str, priority: int = 600):
+        """
+        Apply CSS directly to a specific widget.
+        
+        Args:
+            widget: The GTK widget to apply CSS to.
+            css: CSS string to apply.
+            priority: CSS priority level (default 600).
+        """
+        if widget is None:
+            return
+
+        try:
+            css_provider = Gtk.CssProvider()
+            css_provider.load_from_data(css.encode())
+            widget.get_style_context().add_provider(css_provider, priority)
+        except Exception as e:
+            logger.error(f"Failed to apply CSS to widget: {e}")
+
+
+# Initialize the global theme loader
+_theme_loader = None
+
+
+def get_theme_loader() -> SugarThemeLoader:
+    """Get the global SugarThemeLoader instance."""
+    global _theme_loader
+    if _theme_loader is None:
+        _theme_loader = SugarThemeLoader()
+    return _theme_loader
+
+
+def init_sugar_themes():
+    """Initialize Sugar themes on module load."""
+    loader = get_theme_loader()
+    # Try to load theme from sugar-artwork, fall back to bundled CSS
+    if not loader.load_theme():
+        logger.info("Using fallback CSS from sugar-toolkit-gtk4")

--- a/src/sugar4/graphics/toolbarbox.py
+++ b/src/sugar4/graphics/toolbarbox.py
@@ -247,22 +247,10 @@ class ToolbarBox(Gtk.Box):
         self._apply_styling()
 
     def _apply_styling(self):
+        # Apply Sugar-toolkit CSS classes that are defined in sugar-gtk4.css
+        # or sugar-artwork themes. The CSS is loaded centrally by the theme
+        # loader to avoid duplication and maintain consistency with sugar-artwork.
         self.add_css_class("sugar-toolbarbox")
-
-        css = f"""
-        .sugar-toolbarbox {{
-            background: {style.COLOR_TOOLBAR_GREY.get_css_rgba()};
-        }}
-        .toolbar-expandable-button {{
-            margin: 2px;
-            border-radius: 4px;
-        }}
-        .toolbar-expandable-button.expanded {{
-            background: alpha(@theme_selected_bg_color, 0.2);
-            border-bottom: 2px solid @theme_selected_bg_color;
-        }}
-        """
-        style.apply_css_to_widget(self, css)
 
     def get_toolbar(self):
         return self._toolbar
@@ -477,6 +465,9 @@ def _setup_page(page_widget, color, hpad):
 
     page = _get_embedded_page(page_widget)
     if page:
+        # Apply background color to page dynamically
+        # Note: This uses a dynamic color, so we keep this CSS generation
+        # but could be improved by supporting theme variables
         css = f"""
         * {{
             background: {color.get_css_rgba()};

--- a/src/sugar4/graphics/toolbox.py
+++ b/src/sugar4/graphics/toolbox.py
@@ -76,31 +76,12 @@ class Toolbox(Gtk.Box):
         self._notebook.connect("notify::page", self._notify_page_cb)
 
     def _apply_toolbox_styling(self):
-        """Apply Sugar-style toolbox styling."""
-        css = f"""
-        notebook.toolbox {{
-            background: {style.COLOR_TOOLBAR_GREY.get_css_rgba()};
-        }}
-        notebook.toolbox > header {{
-            background: {style.COLOR_TOOLBAR_GREY.get_css_rgba()};
-            padding: {style.TOOLBOX_TAB_VBORDER}px {style.TOOLBOX_TAB_HBORDER}px;
-        }}
-        notebook.toolbox > header > tabs > tab {{
-            background: transparent;
-            border: none;
-            padding: {style.TOOLBOX_TAB_VBORDER}px {style.TOOLBOX_TAB_HBORDER}px;
-            min-width: {style.TOOLBOX_TAB_LABEL_WIDTH}px;
-        }}
-        notebook.toolbox > header > tabs > tab:checked {{
-            background: alpha(@theme_selected_bg_color, 0.1);
-        }}
-        separator.toolbox-separator {{
-            background: {style.COLOR_PANEL_GREY.get_css_rgba()};
-            min-height: {style.TOOLBOX_SEPARATOR_HEIGHT}px;
-        }}
+        """Apply Sugar-style toolbox styling using centralized CSS classes.
+        
+        CSS classes (defined in sugar-gtk4.css or sugar-artwork themes):
+        - toolbox: Applied to the notebook widget
+        - toolbox-separator: Applied to the separator widget
         """
-        style.apply_css_to_widget(self, css)
-
         self._notebook.add_css_class("toolbox")
         self._separator.add_css_class("toolbox-separator")
 

--- a/src/sugar4/graphics/toolbutton.py
+++ b/src/sugar4/graphics/toolbutton.py
@@ -162,37 +162,13 @@ class ToolButton(Gtk.Button):
         self._apply_toolbar_button_css()
 
     def _apply_toolbar_button_css(self):
-        css = """
-        .toolbar-button {
-            border-radius: 6px;
-            margin: 2px;
-            padding: 6px;
-            min-width: 32px;
-            min-height: 32px;
-        }
-
-        .toolbar-button:hover {
-            background: alpha(@theme_fg_color, 0.1);
-        }
-
-        .toolbar-button:active,
-        .toolbar-button.active {
-            background: alpha(@theme_fg_color, 0.2);
-            border: 1px solid alpha(@theme_fg_color, 0.3);
-        }
-
-        .toolbar-button:focus {
-            outline: 2px solid @theme_selected_bg_color;
-            outline-offset: 2px;
-        }
+        """Apply toolbar button CSS class.
+        
+        CSS styling is defined in sugar-gtk4.css (.toolbar-button class)
+        or sugar-artwork themes, rather than hardcoded here to avoid
+        duplication and maintain consistency with Sugar design.
         """
-
-        try:
-            css_provider = Gtk.CssProvider()
-            css_provider.load_from_string(css)
-            self.get_style_context().add_provider(css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
-        except Exception as e:
-            logging.warning(f"Could not apply toolbar button CSS: {e}")
+        # CSS classes are applied via sugar-gtk4.css (centralized theme)
 
     def __destroy_cb(self, widget):
         if self._palette_invoker is not None:
@@ -460,38 +436,15 @@ class ToolButton(Gtk.Button):
 
 
 def _apply_module_css():
-    """Apply module-level CSS styling."""
-    css = """
-    /* Additional toolbar button styles */
-    .toolbar-button icon {
-        min-width: 24px;
-        min-height: 24px;
-    }
-
-    .toolbar-button label {
-        font-size: 0.9em;
-    }
-
-    /* Ensure proper spacing in horizontal toolbars */
-    toolbar .toolbar-button {
-        margin: 1px;
-    }
-
-    /* Active palette indicator */
-    .toolbar-button.active {
-        box-shadow: inset 0 0 0 2px @theme_selected_bg_color;
-    }
+    """Apply module-level CSS styling for toolbar buttons.
+    
+    CSS styling is centralized in sugar-gtk4.css to avoid duplication
+    and maintain consistency with sugar-artwork themes. This function
+    is kept for backward compatibility but delegates to the theme loader.
     """
-
-    try:
-        css_provider = Gtk.CssProvider()
-        css_provider.load_from_string(css)
-
-        display = Gdk.Display.get_default()
-        if display:
-            Gtk.StyleContext.add_provider_for_display(display, css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
-    except Exception as e:
-        logging.warning(f"Could not apply module CSS: {e}")
+    # CSS is now managed by the centralized theme loader
+    # See: sugar4.graphics.theme.SugarThemeLoader
+    pass
 
 
 try:

--- a/src/sugar4/graphics/tray.py
+++ b/src/sugar4/graphics/tray.py
@@ -701,13 +701,15 @@ class TrayIcon(Gtk.Button):
 
 
 def _apply_tray_css():
-    """Apply CSS styling for tray widgets."""
-    css = """
-    .drag-active {
-        background-color: rgba(0, 0, 0, 0.2);
-    }
+    """Apply CSS styling for tray widgets.
+    
+    CSS styling is defined in sugar-gtk4.css (.drag-active class and 
+    htray/vtray element styles) or sugar-artwork themes to avoid duplication.
+    This function is kept for backward compatibility.
     """
-    style.apply_css_to_widget(None, css)  # Apply globally
+    # CSS is now managed by the centralized theme loader
+    # See: sugar4.graphics.theme.SugarThemeLoader
+    pass
 
 
 try:


### PR DESCRIPTION
# Problem
8 widget components each contained hardcoded CSS causing duplication and making styling changes require Python code modifications.

# Solution
* Added centralized stylesheet for all Sugar widgets
* Added theme loader (210 lines) that prioritizes sugar-artwork, falls back to bundled CSS
* Refactored 8 components to remove CSS generation, keep only CSS class assignment
* Auto-initializes on  import

## Why Bundled CSS?
Enables toolkit to work standalone (dev environments, testing, standalone apps) while preferring sugar-artwork when available.

Fixes #5