### PR TITLE
Replace sugar3 references with sugar4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ help:
 	@echo 'Targets:'
 	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-install:  ## Install package in development mode
-	pip install -e .
+install:  ## Install package
+	pip install --root-user-action=ignore .
 
 test:  ## Run all tests
 	pytest tests/ -v

--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -1,1 +1,1 @@
-dist_bin_SCRIPTS = sugar-activity sugar-activity-web sugar-activity3
+dist_bin_SCRIPTS = sugar-activity sugar-activity-web sugar-activity4

--- a/bin/sugar-activity
+++ b/bin/sugar-activity
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
 
-from sugar3.activity import activityinstance
+from sugar4.activity import activityinstance
 
 activityinstance.main()

--- a/bin/sugar-activity-web
+++ b/bin/sugar-activity-web
@@ -17,4 +17,4 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-exec sugar-activity3 sugar3.activity.webactivity.WebActivity $@
+exec sugar-activity3 sugar4.activity.webactivity.WebActivity $@

--- a/bin/sugar-activity4
+++ b/bin/sugar-activity4
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
 
-from sugar3.activity import activityinstance
+from sugar4.activity import activityinstance
 
 activityinstance.main()

--- a/ci/docs.sh
+++ b/ci/docs.sh
@@ -21,7 +21,7 @@ sudo make
 show-green "Building documentation"
 ./make-doc.sh
 mkdir deploy
-cp -r doc/_build/html deploy/sugar3
+cp -r doc/_build/html deploy/sugar4
 touch deploy/.nojekyll
 # create an index.html so that users don't become confused
 show-green "Writing index.html"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,7 +103,7 @@ autodoc_mock_imports = [
     "dbus",
     "SimpleHTTPServer",
     "socketserver",
-    "sugar3",
+    "sugar4",
     "cairo",
 ]
 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,8 +1,8 @@
-src/sugar3/activity/activity.py
-src/sugar3/activity/widgets.py
-src/sugar3/graphics/alert.py
-src/sugar3/graphics/colorbutton.py
-src/sugar3/graphics/objectchooser.py
-src/sugar3/util.py
-src/sugar3/mime.py
-src/sugar3/speech.py
+src/sugar4/activity/activity.py
+src/sugar4/activity/widgets.py
+src/sugar4/graphics/alert.py
+src/sugar4/graphics/colorbutton.py
+src/sugar4/graphics/objectchooser.py
+src/sugar4/util.py
+src/sugar4/mime.py
+src/sugar4/speech.py

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,7 +1,7 @@
 # We don't care about these string, they are in code which we don't really
 # use and is there solely to not diverge too much from the "upstream"
 # versions of these files.
-src/sugar3/eggdesktopfile.c
-src/sugar3/eggsmclient.c
-src/sugar3/gsm-xsmp.c
+src/sugar4/eggdesktopfile.c
+src/sugar4/eggsmclient.c
+src/sugar4/gsm-xsmp.c
 tests/data/sample.activity/activity.py

--- a/po/sugar-toolkit-gtk3.pot
+++ b/po/sugar-toolkit-gtk3.pot
@@ -18,508 +18,508 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: src/sugar3/activity/activity.py:500
+#: src/sugar4/activity/activity.py:500
 #, python-format
 msgid "%s Activity"
 msgstr ""
 
-#: src/sugar3/activity/activity.py:1150
+#: src/sugar4/activity/activity.py:1150
 msgid "Keep error"
 msgstr ""
 
-#: src/sugar3/activity/activity.py:1151
+#: src/sugar4/activity/activity.py:1151
 msgid "Keep error: all changes will be lost"
 msgstr ""
 
-#: src/sugar3/activity/activity.py:1154
+#: src/sugar4/activity/activity.py:1154
 msgid "Don't stop"
 msgstr ""
 
-#: src/sugar3/activity/activity.py:1158
+#: src/sugar4/activity/activity.py:1158
 msgid "Stop anyway"
 msgstr ""
 
-#: src/sugar3/activity/activity.py:1192 src/sugar3/activity/widgets.py:89
+#: src/sugar4/activity/activity.py:1192 src/sugar4/activity/widgets.py:89
 msgid "Stop"
 msgstr ""
 
-#: src/sugar3/activity/activity.py:1193
+#: src/sugar4/activity/activity.py:1193
 msgid "Stop: name your journal entry"
 msgstr ""
 
-#: src/sugar3/activity/activity.py:1212 src/sugar3/graphics/alert.py:309
-#: src/sugar3/graphics/alert.py:477
+#: src/sugar4/activity/activity.py:1212 src/sugar4/graphics/alert.py:309
+#: src/sugar4/graphics/alert.py:477
 msgid "Cancel"
 msgstr ""
 
-#: src/sugar3/activity/activity.py:1216
+#: src/sugar4/activity/activity.py:1216
 msgid "Cancel stop and continue the activity"
 msgstr ""
 
-#: src/sugar3/activity/activity.py:1253
+#: src/sugar4/activity/activity.py:1253
 msgid "Save new"
 msgstr ""
 
-#: src/sugar3/activity/activity.py:1254
+#: src/sugar4/activity/activity.py:1254
 msgid "Save a new journal entry"
 msgstr ""
 
-#: src/sugar3/activity/activity.py:1257
+#: src/sugar4/activity/activity.py:1257
 msgid "Save"
 msgstr ""
 
-#: src/sugar3/activity/activity.py:1258
+#: src/sugar4/activity/activity.py:1258
 msgid "Save into the old journal entry"
 msgstr ""
 
-#: src/sugar3/activity/activity.py:1264
+#: src/sugar4/activity/activity.py:1264
 msgid "Erase changes"
 msgstr ""
 
-#: src/sugar3/activity/activity.py:1265
+#: src/sugar4/activity/activity.py:1265
 msgid "Erase what you have done, and leave your old journal entry unchanged"
 msgstr ""
 
-#: src/sugar3/activity/activity.py:1268
+#: src/sugar4/activity/activity.py:1268
 msgid "Erase"
 msgstr ""
 
-#: src/sugar3/activity/activity.py:1269
+#: src/sugar4/activity/activity.py:1269
 msgid "Erase what you have done, and avoid making a journal entry"
 msgstr ""
 
-#: src/sugar3/activity/widgets.py:102
+#: src/sugar4/activity/widgets.py:102
 msgid "Undo"
 msgstr ""
 
-#: src/sugar3/activity/widgets.py:110
+#: src/sugar4/activity/widgets.py:110
 msgid "Redo"
 msgstr ""
 
-#: src/sugar3/activity/widgets.py:118
+#: src/sugar4/activity/widgets.py:118
 msgid "Copy"
 msgstr ""
 
-#: src/sugar3/activity/widgets.py:126
+#: src/sugar4/activity/widgets.py:126
 msgid "Paste"
 msgstr ""
 
-#: src/sugar3/activity/widgets.py:137
+#: src/sugar4/activity/widgets.py:137
 msgid "Private"
 msgstr ""
 
-#: src/sugar3/activity/widgets.py:144
+#: src/sugar4/activity/widgets.py:144
 msgid "My Neighborhood"
 msgstr ""
 
-#: src/sugar3/activity/widgets.py:251
+#: src/sugar4/activity/widgets.py:251
 msgid "Description"
 msgstr ""
 
-#: src/sugar3/graphics/alert.py:313 src/sugar3/graphics/alert.py:354
-#: src/sugar3/graphics/alert.py:403 src/sugar3/graphics/alert.py:522
+#: src/sugar4/graphics/alert.py:313 src/sugar4/graphics/alert.py:354
+#: src/sugar4/graphics/alert.py:403 src/sugar4/graphics/alert.py:522
 msgid "Ok"
 msgstr ""
 
-#: src/sugar3/graphics/alert.py:474
+#: src/sugar4/graphics/alert.py:474
 msgid "Continue"
 msgstr ""
 
-#: src/sugar3/graphics/colorbutton.py:61
+#: src/sugar4/graphics/colorbutton.py:61
 msgid "Choose a color"
 msgstr ""
 
-#: src/sugar3/graphics/colorbutton.py:307
+#: src/sugar4/graphics/colorbutton.py:307
 msgid "Red"
 msgstr ""
 
-#: src/sugar3/graphics/colorbutton.py:309
+#: src/sugar4/graphics/colorbutton.py:309
 msgid "Green"
 msgstr ""
 
-#: src/sugar3/graphics/colorbutton.py:311
+#: src/sugar4/graphics/colorbutton.py:311
 msgid "Blue"
 msgstr ""
 
-#: src/sugar3/mime.py:62
+#: src/sugar4/mime.py:62
 msgid "Text"
 msgstr ""
 
-#: src/sugar3/mime.py:69
+#: src/sugar4/mime.py:69
 msgid "Image"
 msgstr ""
 
-#: src/sugar3/mime.py:74
+#: src/sugar4/mime.py:74
 msgid "Audio"
 msgstr ""
 
-#: src/sugar3/mime.py:81
+#: src/sugar4/mime.py:81
 msgid "Video"
 msgstr ""
 
-#: src/sugar3/mime.py:92
+#: src/sugar4/mime.py:92
 msgid "Link"
 msgstr ""
 
-#: src/sugar3/mime.py:97
+#: src/sugar4/mime.py:97
 msgid "Bundle"
 msgstr ""
 
-#: src/sugar3/speech.py:59
+#: src/sugar4/speech.py:59
 msgid "Afrikaans"
 msgstr ""
 
-#: src/sugar3/speech.py:61
+#: src/sugar4/speech.py:61
 msgid "Aragonese"
 msgstr ""
 
-#: src/sugar3/speech.py:63
+#: src/sugar4/speech.py:63
 msgid "Bulgarian"
 msgstr ""
 
-#: src/sugar3/speech.py:65
+#: src/sugar4/speech.py:65
 msgid "Bosnian"
 msgstr ""
 
-#: src/sugar3/speech.py:67
+#: src/sugar4/speech.py:67
 msgid "Catalan"
 msgstr ""
 
-#: src/sugar3/speech.py:69
+#: src/sugar4/speech.py:69
 msgid "Czech"
 msgstr ""
 
-#: src/sugar3/speech.py:71
+#: src/sugar4/speech.py:71
 msgid "Welsh"
 msgstr ""
 
-#: src/sugar3/speech.py:73
+#: src/sugar4/speech.py:73
 msgid "Danish"
 msgstr ""
 
-#: src/sugar3/speech.py:75
+#: src/sugar4/speech.py:75
 msgid "German"
 msgstr ""
 
-#: src/sugar3/speech.py:77
+#: src/sugar4/speech.py:77
 msgid "Greek"
 msgstr ""
 
-#: src/sugar3/speech.py:78
+#: src/sugar4/speech.py:78
 msgid "English"
 msgstr ""
 
-#: src/sugar3/speech.py:80
+#: src/sugar4/speech.py:80
 msgid "English Britain"
 msgstr ""
 
-#: src/sugar3/speech.py:82
+#: src/sugar4/speech.py:82
 msgid "English scottish"
 msgstr ""
 
-#: src/sugar3/speech.py:83
+#: src/sugar4/speech.py:83
 msgid "English-north"
 msgstr ""
 
-#: src/sugar3/speech.py:85
+#: src/sugar4/speech.py:85
 msgid "English_rp"
 msgstr ""
 
-#: src/sugar3/speech.py:87
+#: src/sugar4/speech.py:87
 msgid "English_wmids"
 msgstr ""
 
-#: src/sugar3/speech.py:89
+#: src/sugar4/speech.py:89
 msgid "English USA"
 msgstr ""
 
-#: src/sugar3/speech.py:91
+#: src/sugar4/speech.py:91
 msgid "English West Indies"
 msgstr ""
 
-#: src/sugar3/speech.py:93
+#: src/sugar4/speech.py:93
 msgid "Esperanto"
 msgstr ""
 
-#: src/sugar3/speech.py:95
+#: src/sugar4/speech.py:95
 msgid "Spanish"
 msgstr ""
 
-#: src/sugar3/speech.py:96
+#: src/sugar4/speech.py:96
 msgid "Spanish latin american"
 msgstr ""
 
-#: src/sugar3/speech.py:98
+#: src/sugar4/speech.py:98
 msgid "Estonian"
 msgstr ""
 
-#: src/sugar3/speech.py:100
+#: src/sugar4/speech.py:100
 msgid "Farsi"
 msgstr ""
 
-#: src/sugar3/speech.py:102
+#: src/sugar4/speech.py:102
 msgid "Farsi-pinglish"
 msgstr ""
 
-#: src/sugar3/speech.py:104
+#: src/sugar4/speech.py:104
 msgid "Finnish"
 msgstr ""
 
-#: src/sugar3/speech.py:106
+#: src/sugar4/speech.py:106
 msgid "French belgium"
 msgstr ""
 
-#: src/sugar3/speech.py:108
+#: src/sugar4/speech.py:108
 msgid "French"
 msgstr ""
 
-#: src/sugar3/speech.py:110
+#: src/sugar4/speech.py:110
 msgid "Irish-gaeilge"
 msgstr ""
 
-#: src/sugar3/speech.py:112
+#: src/sugar4/speech.py:112
 msgid "Greek-ancient"
 msgstr ""
 
-#: src/sugar3/speech.py:114
+#: src/sugar4/speech.py:114
 msgid "Hindi"
 msgstr ""
 
-#: src/sugar3/speech.py:116
+#: src/sugar4/speech.py:116
 msgid "Croatian"
 msgstr ""
 
-#: src/sugar3/speech.py:118
+#: src/sugar4/speech.py:118
 msgid "Hungarian"
 msgstr ""
 
-#: src/sugar3/speech.py:120
+#: src/sugar4/speech.py:120
 msgid "Armenian"
 msgstr ""
 
-#: src/sugar3/speech.py:122
+#: src/sugar4/speech.py:122
 msgid "Armenian (west)"
 msgstr ""
 
-#: src/sugar3/speech.py:124
+#: src/sugar4/speech.py:124
 msgid "Indonesian"
 msgstr ""
 
-#: src/sugar3/speech.py:126
+#: src/sugar4/speech.py:126
 msgid "Icelandic"
 msgstr ""
 
-#: src/sugar3/speech.py:128
+#: src/sugar4/speech.py:128
 msgid "Italian"
 msgstr ""
 
-#: src/sugar3/speech.py:130
+#: src/sugar4/speech.py:130
 msgid "Lojban"
 msgstr ""
 
-#: src/sugar3/speech.py:132
+#: src/sugar4/speech.py:132
 msgid "Georgian"
 msgstr ""
 
-#: src/sugar3/speech.py:134
+#: src/sugar4/speech.py:134
 msgid "Kannada"
 msgstr ""
 
-#: src/sugar3/speech.py:136
+#: src/sugar4/speech.py:136
 msgid "Kurdish"
 msgstr ""
 
-#: src/sugar3/speech.py:138
+#: src/sugar4/speech.py:138
 msgid "Latin"
 msgstr ""
 
-#: src/sugar3/speech.py:140
+#: src/sugar4/speech.py:140
 msgid "Lithuanian"
 msgstr ""
 
-#: src/sugar3/speech.py:142
+#: src/sugar4/speech.py:142
 msgid "Latvian"
 msgstr ""
 
-#: src/sugar3/speech.py:144
+#: src/sugar4/speech.py:144
 msgid "Macedonian"
 msgstr ""
 
-#: src/sugar3/speech.py:146
+#: src/sugar4/speech.py:146
 msgid "Malayalam"
 msgstr ""
 
-#: src/sugar3/speech.py:148
+#: src/sugar4/speech.py:148
 msgid "Malay"
 msgstr ""
 
-#: src/sugar3/speech.py:150
+#: src/sugar4/speech.py:150
 msgid "Nepali"
 msgstr ""
 
-#: src/sugar3/speech.py:152
+#: src/sugar4/speech.py:152
 msgid "Dutch"
 msgstr ""
 
-#: src/sugar3/speech.py:154
+#: src/sugar4/speech.py:154
 msgid "Norwegian"
 msgstr ""
 
-#: src/sugar3/speech.py:156
+#: src/sugar4/speech.py:156
 msgid "Punjabi"
 msgstr ""
 
-#: src/sugar3/speech.py:158
+#: src/sugar4/speech.py:158
 msgid "Polish"
 msgstr ""
 
-#: src/sugar3/speech.py:160
+#: src/sugar4/speech.py:160
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: src/sugar3/speech.py:162
+#: src/sugar4/speech.py:162
 msgid "Portuguese (Portugal)"
 msgstr ""
 
-#: src/sugar3/speech.py:164
+#: src/sugar4/speech.py:164
 msgid "Romanian"
 msgstr ""
 
-#: src/sugar3/speech.py:166
+#: src/sugar4/speech.py:166
 msgid "Russian"
 msgstr ""
 
-#: src/sugar3/speech.py:168
+#: src/sugar4/speech.py:168
 msgid "Slovak"
 msgstr ""
 
-#: src/sugar3/speech.py:170
+#: src/sugar4/speech.py:170
 msgid "Albanian"
 msgstr ""
 
-#: src/sugar3/speech.py:172
+#: src/sugar4/speech.py:172
 msgid "Serbian"
 msgstr ""
 
-#: src/sugar3/speech.py:174
+#: src/sugar4/speech.py:174
 msgid "Swedish"
 msgstr ""
 
-#: src/sugar3/speech.py:176
+#: src/sugar4/speech.py:176
 msgid "Swahili"
 msgstr ""
 
-#: src/sugar3/speech.py:178
+#: src/sugar4/speech.py:178
 msgid "Tamil"
 msgstr ""
 
-#: src/sugar3/speech.py:180
+#: src/sugar4/speech.py:180
 msgid "Turkish"
 msgstr ""
 
-#: src/sugar3/speech.py:182
+#: src/sugar4/speech.py:182
 msgid "Vietnam"
 msgstr ""
 
-#: src/sugar3/speech.py:183
+#: src/sugar4/speech.py:183
 msgid "Vietnam_hue"
 msgstr ""
 
-#: src/sugar3/speech.py:184
+#: src/sugar4/speech.py:184
 msgid "Vietnam_sgn"
 msgstr ""
 
-#: src/sugar3/speech.py:186
+#: src/sugar4/speech.py:186
 msgid "Mandarin"
 msgstr ""
 
-#: src/sugar3/speech.py:188
+#: src/sugar4/speech.py:188
 msgid "Cantonese"
 msgstr ""
 
-#: src/sugar3/util.py:225
+#: src/sugar4/util.py:225
 msgid " and "
 msgstr ""
 
-#: src/sugar3/util.py:226
+#: src/sugar4/util.py:226
 msgid ", "
 msgstr ""
 
 #. TRANS: Indicating something that just happened, eg. "just now", "moments ago"
-#: src/sugar3/util.py:229
+#: src/sugar4/util.py:229
 msgid "Seconds ago"
 msgstr ""
 
 #. TRANS: Indicating time passed, eg. "[10 day, 5 hours] ago",
 #. "[2 minutes] in the past", or "[3 years, 1 month] earlier"
-#: src/sugar3/util.py:233
+#: src/sugar4/util.py:233
 #, python-format
 msgid "%s ago"
 msgstr ""
 
 #. TRANS: Relative dates (eg. 1 month and 5 days).
-#: src/sugar3/util.py:248
+#: src/sugar4/util.py:248
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/sugar3/util.py:249
+#: src/sugar4/util.py:249
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/sugar3/util.py:250
+#: src/sugar4/util.py:250
 #, python-format
 msgid "%d week"
 msgid_plural "%d weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/sugar3/util.py:251
+#: src/sugar4/util.py:251
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/sugar3/util.py:252
+#: src/sugar4/util.py:252
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/sugar3/util.py:253
+#: src/sugar4/util.py:253
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/sugar3/util.py:355
+#: src/sugar4/util.py:355
 msgid "Empty"
 msgstr ""
 
-#: src/sugar3/util.py:357
+#: src/sugar4/util.py:357
 #, python-format
 msgid "%d B"
 msgstr ""
 
-#: src/sugar3/util.py:359
+#: src/sugar4/util.py:359
 #, python-format
 msgid "%d KB"
 msgstr ""
 
-#: src/sugar3/util.py:361
+#: src/sugar4/util.py:361
 #, python-format
 msgid "%d MB"
 msgstr ""
 
-#: src/sugar3/util.py:363
+#: src/sugar4/util.py:363
 #, python-format
 msgid "%d GB"
 msgstr ""

--- a/src/sugar4/graphics/icon.py
+++ b/src/sugar4/graphics/icon.py
@@ -674,6 +674,7 @@ class Icon(Gtk.Image):
 
         Returns:
             str, SVG color string, like '#FFFFFF'
+        '''
 
         return self._buffer.fill_color
 

--- a/src/sugar4/graphics/icon.py
+++ b/src/sugar4/graphics/icon.py
@@ -56,6 +56,7 @@ from gi.repository import GLib, GObject, Gtk, Gdk, GdkPixbuf, Rsvg
 import cairo
 
 from sugar4.graphics.xocolor import XoColor
+from sugar4.graphics import style
 
 
 # Simple LRU cache implementation
@@ -87,12 +88,6 @@ class _LRU:
 
 
 _BADGE_SIZE = 0.45
-_DEFAULT_ICON_SIZE = 48
-
-# Icon size constants
-SMALL_ICON_SIZE = 16
-STANDARD_ICON_SIZE = 48
-LARGE_ICON_SIZE = 96
 
 
 class _SVGLoader:
@@ -165,8 +160,8 @@ class _IconBuffer:
         self.stroke_color: Optional[str] = None
         self.background_color: Optional[Gdk.RGBA] = None
         self.badge_name: Optional[str] = None
-        self.width: int = _DEFAULT_ICON_SIZE
-        self.height: int = _DEFAULT_ICON_SIZE
+        self.width: int = style.STANDARD_ICON_SIZE
+        self.height: int = style.STANDARD_ICON_SIZE
         self.cache: bool = True
         self.scale: float = 1.0
         self.pixbuf: Optional[GdkPixbuf.Pixbuf] = None
@@ -554,25 +549,42 @@ class _IconBuffer:
     xo_color = property(_get_xo_color, _set_xo_color)
 
 
-class Icon(Gtk.Widget):
-    """
-    Basic Sugar icon widget.
+class Icon(Gtk.Image):
+    '''
+     The most basic Sugar icon class.  Displays the icon given.
 
-    Displays themed icons with Sugar's color customization features.
-    Uses modern snapshot-based rendering for improved performance.
+     You must set either the `file_name`, `file` or `icon_name` properties,
+     otherwise, no icon will be visible.
 
-    Properties:
-        icon_name (str): Icon name from theme
-        file_name (str): Path to icon file
-        pixel_size (int): Size in pixels
-        fill_color (str): Fill color as hex string
-        stroke_color (str): Stroke color as hex string
-        xo_color (XoColor): Sugar color pair
-        badge_name (str): Badge icon name
-        alpha (float): Icon transparency (0.0-1.0)
-        scale (float): Icon scale factor
-        sensitive (bool): Whether icon appears sensitive
-    """
+     You should set the `pixel_size`, using constants the `*_ICON_SIZE`
+     constants from :any:`sugar4.graphics.style`.
+
+     You should set the color (either via `xo_color` or `fill_color` and
+     `stroke_color`), otherwise the default black and white fill and stroke
+     will be used.
+
+     Keyword Args:
+         icon_name (str): Icon name from theme
+         file_name (str): a path to the SVG icon file
+         file (object): same behaviour as file_name, but for
+             :class:`sugar3.util.TempFilePath` type objects
+         icon_name (str): a name of an icon in the theme to display.  The
+             icons in the theme include those in the sugar-artwork project
+             and icons in the activity's '/icons' directory
+         pixel_size (int): size of the icon, in pixels.  Best to use the
+             constants from :class:`sugar3.graphics.style`, as those constants
+             are scaled based on the user's preferences
+         xo_color (sugar3.graphics.xocolor.XoColor): color to display icon,
+             a shortcut that just sets the fill_color and stroke_color
+         fill_color (str): a string, like '#FFFFFF', that will serve as the
+             fill color for the icon
+         stroke_color (str): a string, like '#282828', that will serve as the
+             stroke color for the icon
+         badge_name (str): the icon_name for a badge icon,
+             see :any:`set_badge_name`
+         alpha (float): transparency of the icon, defaults to 1.0
+         sensitive (bool): Whether icon appears sensitive
+     '''
 
     __gtype_name__ = "SugarIcon"
 
@@ -580,7 +592,7 @@ class Icon(Gtk.Widget):
         self,
         icon_name: Optional[str] = None,
         file_name: Optional[str] = None,
-        pixel_size: int = STANDARD_ICON_SIZE,
+        pixel_size: int = style.STANDARD_ICON_SIZE,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -657,6 +669,12 @@ class Icon(Gtk.Widget):
             self.queue_resize()
 
     def get_fill_color(self) -> Optional[str]:
+        '''
+        Get the color used to fill the icon
+
+        Returns:
+            str, SVG color string, like '#FFFFFF'
+
         return self._buffer.fill_color
 
     def set_fill_color(self, color: Optional[str]):
@@ -676,6 +694,12 @@ class Icon(Gtk.Widget):
         return self._buffer._get_xo_color()
 
     def set_xo_color(self, xo_color: Optional[XoColor]):
+        '''
+        Set the colors used to display the icon
+
+        Args:
+            value (sugar3.graphics.xocolor.XoColor): new XoColor to use
+        '''
         if not hasattr(self, "_buffer") or self._buffer is None:
             self._buffer = _IconBuffer()
         if self._buffer._get_xo_color() != xo_color:
@@ -719,7 +743,7 @@ class Icon(Gtk.Widget):
     )
     pixel_size = GObject.Property(
         type=int,
-        default=STANDARD_ICON_SIZE,
+        default=style.STANDARD_ICON_SIZE,
         getter=get_pixel_size,
         setter=set_pixel_size,
     )
@@ -751,26 +775,6 @@ class Icon(Gtk.Widget):
         if self._buffer.pixbuf != pixbuf:
             self._buffer.pixbuf = pixbuf
             self.queue_draw()
-
-    def get_gtk_image(self) -> Gtk.Image:
-        """
-        Create a Gtk.Image from this icon for compatibility.
-
-        Returns:
-            Gtk.Image: Image widget with icon content
-        """
-        surface = self._buffer.get_surface(self.get_sensitive())
-        if surface:
-            # Convert surface to pixbuf then to texture
-            pixbuf = Gdk.pixbuf_get_from_surface(
-                surface, 0, 0, surface.get_width(), surface.get_height()
-            )
-            if pixbuf:
-                texture = Gdk.Texture.new_for_pixbuf(pixbuf)
-                image = Gtk.Image.new_from_paintable(texture)
-                return image
-
-        return Gtk.Image.new_from_icon_name("image-missing")
 
 
 class EventIcon(Icon):
@@ -1001,7 +1005,7 @@ def get_icon_file_name(icon_name: str) -> Optional[str]:
     icon_paintable = icon_theme.lookup_icon(
         icon_name,
         None,
-        STANDARD_ICON_SIZE,
+        style.STANDARD_ICON_SIZE,
         1,
         Gtk.TextDirection.NONE,
         Gtk.IconLookupFlags.NONE,
@@ -1044,7 +1048,7 @@ def get_surface(
     file_name: Optional[str] = None,
     fill_color: Optional[str] = None,
     stroke_color: Optional[str] = None,
-    pixel_size: int = STANDARD_ICON_SIZE,
+    pixel_size: int = style.STANDARD_ICON_SIZE,
     **kwargs,
 ) -> Optional[cairo.ImageSurface]:
     """

--- a/src/sugar4/graphics/menuitem.py
+++ b/src/sugar4/graphics/menuitem.py
@@ -38,12 +38,9 @@ from sugar4.graphics.icon import Icon
 from sugar4.graphics import style
 
 
-class MenuItem(Gtk.Button):
+class MenuItem(Gio.MenuItem):
     """
     A Sugar-style menu item with icon and text support.
-
-    This replaces the deprecated ImageMenuItem with a Button
-    that can be used in menus and popover menus.
 
     Args:
         text_label (str): Text to display on the menu item
@@ -68,67 +65,36 @@ class MenuItem(Gtk.Button):
         self._accelerator = None
         self._action_name = None
 
-        # horizontal box for content
-        content_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-        content_box.set_margin_start(6)
-        content_box.set_margin_end(6)
-        content_box.set_margin_top(4)
-        content_box.set_margin_bottom(4)
-
         if icon_name is not None:
             icon = Icon(icon_name=icon_name, pixel_size=style.SMALL_ICON_SIZE)
             if xo_color is not None:
                 icon.set_xo_color(xo_color)
-            content_box.append(icon)
+            self.set_icon(icon.get_gicon())
         elif file_name is not None:
             icon = Icon(file_name=file_name, pixel_size=style.SMALL_ICON_SIZE)
             if xo_color is not None:
                 icon.set_xo_color(xo_color)
-            content_box.append(icon)
+            self.set_icon(icon.get_gicon())
 
-        if text_label is not None:
-            self._label = Gtk.Label(label=text_label)
-            self._label.set_halign(Gtk.Align.START)
-            self._label.set_hexpand(True)
-            # Force label text to black
-            self._label.add_css_class("force-black")
-            style.apply_css_to_widget(self._label, ".force-black { color: #000000; }")
+        self._label = Gtk.Label(label=text_label)
+        self._label.set_halign(Gtk.Align.START)
+        self._label.set_hexpand(True)
+        # Force label text to black
+        self._label.add_css_class("force-black")
+        style.apply_css_to_widget(self._label, ".force-black { color: #000000; }")
 
-            if text_maxlen > 0:
-                self._label.set_ellipsize(style.ELLIPSIZE_MODE_DEFAULT)
-                self._label.set_max_width_chars(text_maxlen)
+        if text_maxlen > 0:
+            self._label.set_ellipsize(style.ELLIPSIZE_MODE_DEFAULT)
+            self._label.set_max_width_chars(text_maxlen)
 
-            content_box.append(self._label)
-        else:
-            self._label = None
-
-        self.set_child(content_box)
+        self.set_label(self._label)
 
         # Style the button to look like a menu item
         self.add_css_class("menuitem")
-        self._apply_menu_item_styling()
 
         # Connect signals for accelerator handling
         self.connect("map", self._on_mapped)
         self.connect("unmap", self._on_unmapped)
-
-    def _apply_menu_item_styling(self):
-        """Apply CSS styling to make button look like a menu item."""
-        css = """
-        button.menuitem {
-            background: transparent;
-            border: none;
-            border-radius: 4px;
-            padding: 4px 6px;
-        }
-        button.menuitem:hover {
-            background: alpha(@theme_selected_bg_color, 0.1);
-        }
-        button.menuitem:active {
-            background: alpha(@theme_selected_bg_color, 0.2);
-        }
-        """
-        style.apply_css_to_widget(self, css)
 
     def _on_mapped(self, widget):
         """Handle widget being mapped (shown)."""
@@ -232,6 +198,9 @@ class MenuItem(Gtk.Button):
         if self._label:
             return self._label.get_text()
         return ""
+
+    def set_image(self, icon):
+        self.set_icon(icon.get_gicon())
 
     # Properties for compatibility
     accelerator = GObject.Property(

--- a/src/sugar4/graphics/menuitem.py
+++ b/src/sugar4/graphics/menuitem.py
@@ -38,7 +38,7 @@ from sugar4.graphics.icon import Icon
 from sugar4.graphics import style
 
 
-class MenuItem(Gio.MenuItem):
+class MenuItem(Gtk.Button):
     """
     A Sugar-style menu item with icon and text support.
 
@@ -65,16 +65,23 @@ class MenuItem(Gio.MenuItem):
         self._accelerator = None
         self._action_name = None
 
+        # horizontal box for content
+        content_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        content_box.set_margin_start(6)
+        content_box.set_margin_end(6)
+        content_box.set_margin_top(4)
+        content_box.set_margin_bottom(4)
+
         if icon_name is not None:
             icon = Icon(icon_name=icon_name, pixel_size=style.SMALL_ICON_SIZE)
             if xo_color is not None:
                 icon.set_xo_color(xo_color)
-            self.set_icon(icon.get_gicon())
+            content_box.append(icon)
         elif file_name is not None:
             icon = Icon(file_name=file_name, pixel_size=style.SMALL_ICON_SIZE)
             if xo_color is not None:
                 icon.set_xo_color(xo_color)
-            self.set_icon(icon.get_gicon())
+            content_box.append(icon)
 
         self._label = Gtk.Label(label=text_label)
         self._label.set_halign(Gtk.Align.START)
@@ -87,7 +94,7 @@ class MenuItem(Gio.MenuItem):
             self._label.set_ellipsize(style.ELLIPSIZE_MODE_DEFAULT)
             self._label.set_max_width_chars(text_maxlen)
 
-        self.set_label(self._label)
+        self.set_child(content_box)
 
         # Style the button to look like a menu item
         self.add_css_class("menuitem")


### PR DESCRIPTION
I've also removed the redefinitions of *ICON_SIZE in sugar4.graphics.icon, we had all that defined in style so duplicating wasn't necessary.

I moved Icon from a Gtk.Widget back to a Gtk.Image, I don't see why it was changed before as Gtk.Image still exists and is expected to be the same. There was no need for a Icon.get_gtk_image seeing as I moved back to Gtk.Image.

MenuItem has been moved to a Gio.MenuItem, with a Gtk.Box, css styling was applied directly and I think that's not needed as we have a menuitem styling in sugar-artwork.


@MostlyKIGuess kindly review.