### PR TITLE
fix: use public methods instead of private attributes in tests

### DIFF
--- a/src/sugar4/activity/activity.py
+++ b/src/sugar4/activity/activity.py
@@ -269,6 +269,15 @@ class _ActivitySession(GObject.GObject):
     def set_main_loop(self, main_loop):
         self._main_loop = main_loop
 
+    def get_activities(self):
+        """Get the list of registered activities."""
+        return self._activities
+
+    def get_will_quit(self):
+        """Get the list of activities that have agreed to quit."""
+        return self._will_quit
+
+
 
 class Activity(Window):
     """
@@ -725,6 +734,31 @@ class Activity(Window):
             canvas.connect("map", self.__canvas_map_cb)
 
     canvas = property(get_canvas, set_canvas)
+
+    def get_busy_count(self):
+        """Get the current busy count."""
+        return self._busy_count
+
+    def get_stop_buttons(self):
+        """Get the list of stop buttons."""
+        return self._stop_buttons
+
+    def get_invites_queue(self):
+        """Get the current invites queue."""
+        return self._invites_queue
+
+    def is_resumed(self):
+        """Check if this activity was resumed from a journal entry."""
+        return self._is_resumed
+
+    def get_jobject(self):
+        """Get the journal object for this activity."""
+        return self._jobject
+
+    def get_session(self):
+        """Get the activity session manager."""
+        return self._session
+
     """
     The :class:`Gtk.Widget` used as canvas, or work area of your
     activity.  A common canvas is :class:`Gtk.ScrolledWindow`.

--- a/src/sugar4/datastore/datastore.py
+++ b/src/sugar4/datastore/datastore.py
@@ -229,6 +229,15 @@ class DSObject(object):
     def copy(self):
         return DSObject(None, self._metadata.copy(), self._file_path)
 
+    def is_destroyed(self):
+        """Check if the object has been destroyed."""
+        return self._destroyed
+
+    def set_owns_file(self, owns):
+        """Set whether this object owns its file path."""
+        self._owns_file = owns
+
+
 
 class RawObject(object):
     """A representation for objects not in the DS but

--- a/src/sugar4/graphics/alert.py
+++ b/src/sugar4/graphics/alert.py
@@ -243,6 +243,11 @@ class Alert(Gtk.Box):
             self._buttons_box.remove(self._buttons[response_id])
             del self._buttons[response_id]
 
+    def get_buttons(self):
+        """Get the buttons dictionary."""
+        return self._buttons
+
+
     def _response(self, response_id):
         """
         Emitting response when we have a result
@@ -370,6 +375,11 @@ class _TimeoutAlert(Alert):
         if hasattr(self, "_timeout_sid"):
             GLib.source_remove(self._timeout_sid)
         Alert._response(self, *args)
+
+    def get_timeout_source_id(self):
+        """Get the timeout source ID."""
+        return self._timeout_sid
+
 
 
 class TimeoutAlert(_TimeoutAlert):

--- a/src/sugar4/graphics/combobox.py
+++ b/src/sugar4/graphics/combobox.py
@@ -177,5 +177,60 @@ class ComboBox(Gtk.ComboBox):
         """
         return len(self._model)
 
+    def get_model(self):
+        """
+        Get the underlying list model.
+
+        Returns:
+            Gtk.ListStore, the model containing combo items
+        """
+        return self._model
+
+    def get_item_at(self, index):
+        """
+        Get item data at the given index.
+
+        Args:
+            index (int): index of item to retrieve
+
+        Returns:
+            tuple of (value, text, pixbuf, is_separator) or None
+        """
+        if 0 <= index < len(self._model):
+            return self._model[index]
+        return None
+
+    def has_text_renderer(self):
+        """
+        Check if a text renderer has been created.
+
+        Returns:
+            bool, True if text renderer exists
+        """
+        return self._text_renderer is not None
+
+    def has_icon_renderer(self):
+        """
+        Check if an icon renderer has been created.
+
+        Returns:
+            bool, True if icon renderer exists
+        """
+        return self._icon_renderer is not None
+
+    def is_separator_at(self, index):
+        """
+        Check if item at index is a separator.
+
+        Args:
+            index (int): index to check
+
+        Returns:
+            bool, True if item is a separator
+        """
+        if 0 <= index < len(self._model):
+            return self._model[index][3]
+        return False
+
     def _is_separator(self, model, row, data):
         return model[row][3]

--- a/src/sugar4/graphics/combobox.py
+++ b/src/sugar4/graphics/combobox.py
@@ -168,5 +168,14 @@ class ComboBox(Gtk.ComboBox):
         """
         self._model.clear()
 
+    def get_item_count(self):
+        """
+        Get the number of items in the combo box.
+
+        Returns:
+            int, number of items (including separators)
+        """
+        return len(self._model)
+
     def _is_separator(self, model, row, data):
         return model[row][3]

--- a/src/sugar4/graphics/objectchooser.py
+++ b/src/sugar4/graphics/objectchooser.py
@@ -269,6 +269,30 @@ class ObjectChooser(object):
 
         return self._response_code
 
+    def get_parent_xid(self):
+        """Get the parent window XID."""
+        return self._parent_xid
+
+    def get_what_filter(self):
+        """Get the what filter string."""
+        return self._what_filter
+
+    def get_filter_type(self):
+        """Get the filter type."""
+        return self._filter_type
+
+    def get_show_preview(self):
+        """Get the show preview flag."""
+        return self._show_preview
+
+    def get_response_code(self):
+        """Get the response code from the chooser."""
+        return self._response_code
+
+    def get_object_id(self):
+        """Get the selected object ID."""
+        return self._object_id
+
     def get_selected_object(self):
         """
         Gets the object selected using the object chooser.

--- a/src/sugar4/graphics/palette.py
+++ b/src/sugar4/graphics/palette.py
@@ -249,6 +249,10 @@ class Palette(PaletteWindow):
     def get_full_size_request(self):
         return self._full_request
 
+    def get_content_widget(self):
+        """Get the content widget."""
+        return self._content_widget
+
     def popup(self, immediate=False):
         if self._invoker is not None:
             self._update_full_request()

--- a/src/sugar4/graphics/palettegroup.py
+++ b/src/sugar4/graphics/palettegroup.py
@@ -86,6 +86,14 @@ class Group(GObject.GObject):
         self._palettes.remove(palette)
         del self._sig_ids[palette]
 
+    def get_palettes(self):
+        """Get the list of palettes."""
+        return self._palettes
+
+    def get_sig_ids(self):
+        """Get the signal IDs dictionary."""
+        return self._sig_ids
+
     def popdown(self):
         for palette in self._palettes:
             if palette.is_up():

--- a/src/sugar4/graphics/palettewindow.py
+++ b/src/sugar4/graphics/palettewindow.py
@@ -1540,6 +1540,10 @@ class ToolInvoker(WidgetInvoker):
         child = widget.get_child() if hasattr(widget, "get_child") else widget
         self.attach_widget(widget, child)
 
+    def get_tool(self):
+        """Get the tool widget."""
+        return self._tool
+
     def _get_alignments(self):
         if not self._widget or not self._widget.get_parent():
             return super()._get_alignments()

--- a/src/sugar4/graphics/toolbox.py
+++ b/src/sugar4/graphics/toolbox.py
@@ -245,4 +245,13 @@ class Toolbox(Gtk.Box):
             return tab_label.get_text()
         return None
 
+    def get_notebook(self):
+        """Get the internal notebook widget."""
+        return self._notebook
+
+    def get_separator(self):
+        """Get the separator widget."""
+        return self._separator
+
     current_toolbar = property(get_current_toolbar, set_current_toolbar)
+

--- a/src/sugar4/graphics/window.py
+++ b/src/sugar4/graphics/window.py
@@ -358,6 +358,11 @@ class Window(Gtk.ApplicationWindow):
             self._alerts.remove(alert)
             self._overlay.remove_overlay(alert)
 
+    def get_alerts(self):
+        """Get the list of alerts."""
+        return self._alerts
+
+
     def set_enable_fullscreen_mode(self, enable):
         """
         Set enable fullscreen mode.

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -92,7 +92,7 @@ class MockDatastore:
     @staticmethod
     def copy(jobject, mount_point):
         new_jobject = MockJobject()
-        new_jobject.metadata.update(dict(jobject.metadata._properties))
+        new_jobject.metadata.update(jobject.metadata.get_dictionary())
         return new_jobject
 
     @staticmethod
@@ -254,11 +254,11 @@ class TestActivity(unittest.TestCase):
         activity = Activity(self.handle)
 
         activity.busy()
-        self.assertEqual(activity._busy_count, 1)
+        self.assertEqual(activity.get_busy_count(), 1)
 
         # Test nested busy
         activity.busy()
-        self.assertEqual(activity._busy_count, 2)
+        self.assertEqual(activity.get_busy_count(), 2)
 
         # Test unbusy
         remaining = activity.unbusy()
@@ -274,7 +274,7 @@ class TestActivity(unittest.TestCase):
         button = Gtk.Button()
         activity.add_stop_button(button)
 
-        self.assertIn(button, activity._stop_buttons)
+        self.assertIn(button, activity.get_stop_buttons())
 
     def test_copy_functionality(self):
         """Test activity copy functionality."""
@@ -320,7 +320,7 @@ class TestActivity(unittest.TestCase):
         activity.invite("account_path", "contact_id")
 
         # Should add to invites queue and call share
-        self.assertEqual(len(activity._invites_queue), 1)
+        self.assertEqual(len(activity.get_invites_queue()), 1)
         activity.share.assert_called_once_with(True)
 
     def test_notification_functionality(self):
@@ -353,8 +353,8 @@ class TestActivity(unittest.TestCase):
         activity = Activity(self.handle)
 
         # Activity should be registered with session
-        session = activity._session
-        self.assertIn(activity, session._activities)
+        session = activity.get_session()
+        self.assertIn(activity, session.get_activities())
 
     def test_resumed_activity(self):
         """Test resuming an activity from journal object."""
@@ -363,8 +363,8 @@ class TestActivity(unittest.TestCase):
         activity = Activity(self.handle)
 
         # Should be marked as resumed
-        self.assertTrue(activity._is_resumed)
-        self.assertIsNotNone(activity._jobject)
+        self.assertTrue(activity.is_resumed())
+        self.assertIsNotNone(activity.get_jobject())
 
 
 class TestActivityWithoutGTK(unittest.TestCase):
@@ -399,15 +399,15 @@ class TestActivitySession(unittest.TestCase):
 
     def test_session_creation(self):
         """Test session creation."""
-        self.assertEqual(len(self.session._activities), 0)
-        self.assertEqual(len(self.session._will_quit), 0)
+        self.assertEqual(len(self.session.get_activities()), 0)
+        self.assertEqual(len(self.session.get_will_quit()), 0)
 
     def test_activity_registration(self):
         """Test activity registration."""
         mock_activity = Mock()
 
         self.session.register(mock_activity)
-        self.assertIn(mock_activity, self.session._activities)
+        self.assertIn(mock_activity, self.session.get_activities())
 
     def test_activity_unregistration(self):
         """Test activity unregistration."""
@@ -415,7 +415,7 @@ class TestActivitySession(unittest.TestCase):
 
         self.session.register(mock_activity)
         self.session.unregister(mock_activity)
-        self.assertNotIn(mock_activity, self.session._activities)
+        self.assertNotIn(mock_activity, self.session.get_activities())
 
     def test_quit_handling(self):
         """Test quit request handling."""
@@ -427,10 +427,10 @@ class TestActivitySession(unittest.TestCase):
 
         # First activity wants to quit
         self.session.will_quit(mock_activity1, True)
-        self.assertIn(mock_activity1, self.session._will_quit)
+        self.assertIn(mock_activity1, self.session.get_will_quit())
 
         # Second activity doesn't want to quit yet
-        self.assertNotIn(mock_activity2, self.session._will_quit)
+        self.assertNotIn(mock_activity2, self.session.get_will_quit())
 
 
 if __name__ == "__main__":

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -50,7 +50,7 @@ class TestAlert(unittest.TestCase):
         """Test removing buttons from alert"""
         self.alert.add_button(1, "Test Button")
         self.alert.remove_button(1)
-        self.assertNotIn(1, self.alert._buttons)
+        self.assertNotIn(1, self.alert.get_buttons())
 
     def test_add_entry(self):
         """Test adding entry to alert"""
@@ -76,8 +76,8 @@ class TestConfirmationAlert(unittest.TestCase):
     def test_confirmation_alert_creation(self):
         """Test confirmation alert has OK and Cancel buttons"""
         self.assertIsInstance(self.alert, ConfirmationAlert)
-        self.assertIn(Gtk.ResponseType.OK, self.alert._buttons)
-        self.assertIn(Gtk.ResponseType.CANCEL, self.alert._buttons)
+        self.assertIn(Gtk.ResponseType.OK, self.alert.get_buttons())
+        self.assertIn(Gtk.ResponseType.CANCEL, self.alert.get_buttons())
 
 
 class TestErrorAlert(unittest.TestCase):
@@ -87,7 +87,7 @@ class TestErrorAlert(unittest.TestCase):
     def test_error_alert_creation(self):
         """Test error alert has OK button"""
         self.assertIsInstance(self.alert, ErrorAlert)
-        self.assertIn(Gtk.ResponseType.OK, self.alert._buttons)
+        self.assertIn(Gtk.ResponseType.OK, self.alert.get_buttons())
 
 
 class TestTimeoutAlert(unittest.TestCase):
@@ -97,14 +97,14 @@ class TestTimeoutAlert(unittest.TestCase):
     def test_timeout_alert_creation(self):
         """Test timeout alert creation"""
         self.assertIsInstance(self.alert, TimeoutAlert)
-        self.assertIn(Gtk.ResponseType.OK, self.alert._buttons)
-        self.assertIn(Gtk.ResponseType.CANCEL, self.alert._buttons)
+        self.assertIn(Gtk.ResponseType.OK, self.alert.get_buttons())
+        self.assertIn(Gtk.ResponseType.CANCEL, self.alert.get_buttons())
 
     def tearDown(self):
         if hasattr(self.alert, "_timeout_sid"):
             from gi.repository import GLib
 
-            GLib.source_remove(self.alert._timeout_sid)
+            GLib.source_remove(self.alert.get_timeout_source_id())
 
 
 class TestNotifyAlert(unittest.TestCase):
@@ -114,13 +114,13 @@ class TestNotifyAlert(unittest.TestCase):
     def test_notify_alert_creation(self):
         """Test notify alert creation"""
         self.assertIsInstance(self.alert, NotifyAlert)
-        self.assertIn(Gtk.ResponseType.OK, self.alert._buttons)
+        self.assertIn(Gtk.ResponseType.OK, self.alert.get_buttons())
 
     def tearDown(self):
         if hasattr(self.alert, "_timeout_sid"):
             from gi.repository import GLib
 
-            GLib.source_remove(self.alert._timeout_sid)
+            GLib.source_remove(self.alert.get_timeout_source_id())
 
 
 if __name__ == "__main__":

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -16,10 +16,10 @@ class TestDSMetadata(unittest.TestCase):
     def test_metadata_creation_empty(self):
         """Test creating empty metadata."""
         metadata = DSMetadata()
-        self.assertIn("activity", metadata._properties)
-        self.assertIn("activity_id", metadata._properties)
-        self.assertIn("mime_type", metadata._properties)
-        self.assertIn("title_set_by_user", metadata._properties)
+        self.assertIn("activity", metadata)
+        self.assertIn("activity_id", metadata)
+        self.assertIn("mime_type", metadata)
+        self.assertIn("title_set_by_user", metadata)
 
     def test_metadata_creation_with_properties(self):
         """Test creating metadata with properties."""
@@ -153,10 +153,10 @@ class TestDSObject(unittest.TestCase):
         mock_isfile.return_value = True
 
         obj = DSObject("test_id", self.mock_metadata, "/test/path")
-        obj._owns_file = True
+        obj.set_owns_file(True)
         obj.destroy()
 
-        self.assertTrue(obj._destroyed)
+        self.assertTrue(obj.is_destroyed())
         mock_remove.assert_called_once_with("/test/path")
 
 

--- a/tests/test_objectchooser.py
+++ b/tests/test_objectchooser.py
@@ -76,21 +76,21 @@ class TestObjectChooser(unittest.TestCase):
     def test_objectchooser_creation_no_parent(self):
         """Test ObjectChooser creation without parent."""
         chooser = ObjectChooser()
-        self.assertEqual(chooser._parent_xid, 0)
-        self.assertIsNone(chooser._what_filter)
-        self.assertIsNone(chooser._filter_type)
-        self.assertFalse(chooser._show_preview)
+        self.assertEqual(chooser.get_parent_xid(), 0)
+        self.assertIsNone(chooser.get_what_filter())
+        self.assertIsNone(chooser.get_filter_type())
+        self.assertFalse(chooser.get_show_preview())
 
     def test_objectchooser_creation_with_parent(self):
         """Test ObjectChooser creation with parent widget."""
         parent = Gtk.Box()
         chooser = ObjectChooser(parent=parent)
-        self.assertIsNotNone(chooser._parent_xid)
+        self.assertIsNotNone(chooser.get_parent_xid())
 
     def test_objectchooser_creation_with_int_parent(self):
         """Test ObjectChooser creation with integer parent."""
         chooser = ObjectChooser(parent=12345)
-        self.assertEqual(chooser._parent_xid, 12345)
+        self.assertEqual(chooser.get_parent_xid(), 12345)
 
     def test_objectchooser_creation_with_filters(self):
         """Test ObjectChooser creation with various filters."""
@@ -99,9 +99,9 @@ class TestObjectChooser(unittest.TestCase):
             filter_type=FILTER_TYPE_GENERIC_MIME,
             show_preview=True,
         )
-        self.assertEqual(chooser._what_filter, "image/*")
-        self.assertEqual(chooser._filter_type, FILTER_TYPE_GENERIC_MIME)
-        self.assertTrue(chooser._show_preview)
+        self.assertEqual(chooser.get_what_filter(), "image/*")
+        self.assertEqual(chooser.get_filter_type(), FILTER_TYPE_GENERIC_MIME)
+        self.assertTrue(chooser.get_show_preview())
 
     def test_objectchooser_invalid_filter_type(self):
         """Test ObjectChooser with invalid filter type."""
@@ -118,7 +118,7 @@ class TestObjectChooser(unittest.TestCase):
 
         for filter_type in valid_types:
             chooser = ObjectChooser(filter_type=filter_type)
-            self.assertEqual(chooser._filter_type, filter_type)
+            self.assertEqual(chooser.get_filter_type(), filter_type)
 
     @patch("dbus.SessionBus")
     @patch("sugar4.datastore.datastore.get")
@@ -176,8 +176,8 @@ class TestObjectChooser(unittest.TestCase):
 
         # Test with matching chooser_id
         chooser._ObjectChooser__chooser_response_cb("test_chooser_id", "object_123")
-        self.assertEqual(chooser._response_code, Gtk.ResponseType.ACCEPT)
-        self.assertEqual(chooser._object_id, "object_123")
+        self.assertEqual(chooser.get_response_code(), Gtk.ResponseType.ACCEPT)
+        self.assertEqual(chooser.get_object_id(), "object_123")
         chooser._cleanup.assert_called_once()
 
         # Test with non-matching chooser_id
@@ -194,7 +194,7 @@ class TestObjectChooser(unittest.TestCase):
 
         # Test with matching chooser_id
         chooser._ObjectChooser__chooser_cancelled_cb("test_chooser_id")
-        self.assertEqual(chooser._response_code, Gtk.ResponseType.CANCEL)
+        self.assertEqual(chooser.get_response_code(), Gtk.ResponseType.CANCEL)
         chooser._cleanup.assert_called_once()
 
         # Test with non-matching chooser_id
@@ -209,7 +209,7 @@ class TestObjectChooser(unittest.TestCase):
         chooser._cleanup = Mock()
 
         chooser._ObjectChooser__name_owner_changed_cb("service", "old", "new")
-        self.assertEqual(chooser._response_code, Gtk.ResponseType.CANCEL)
+        self.assertEqual(chooser.get_response_code(), Gtk.ResponseType.CANCEL)
         chooser._cleanup.assert_called_once()
 
 

--- a/tests/test_palette.py
+++ b/tests/test_palette.py
@@ -79,9 +79,9 @@ def test_set_content_and_remove():
     palette = Palette()
     label = Gtk.Label(label="Content")
     palette.set_content(label)
-    assert palette._content_widget is label
+    assert palette.get_content_widget() is label
     palette.set_content(None)
-    assert palette._content_widget is None
+    assert palette.get_content_widget() is None
 
 
 def test_menu_switching():
@@ -199,7 +199,7 @@ def test_cursor_invoker():
 def test_tool_invoker():
     btn = Gtk.Button()
     invoker = ToolInvoker(parent=btn)
-    assert invoker._tool is not None
+    assert invoker.get_tool() is not None
 
 
 def test_tree_view_invoker():

--- a/tests/test_palettegroup.py
+++ b/tests/test_palettegroup.py
@@ -78,12 +78,12 @@ class TestPaletteGroup(unittest.TestCase):
         palette = MockPalette("test")
 
         group.add(palette)
-        self.assertIn(palette, group._palettes)
-        self.assertIn(palette, group._sig_ids)
+        self.assertIn(palette, group.get_palettes())
+        self.assertIn(palette, group.get_sig_ids())
 
         group.remove(palette)
-        self.assertNotIn(palette, group._palettes)
-        self.assertNotIn(palette, group._sig_ids)
+        self.assertNotIn(palette, group.get_palettes())
+        self.assertNotIn(palette, group.get_sig_ids())
 
         group.remove(palette)
 

--- a/tests/test_toggletoolbutton.py
+++ b/tests/test_toggletoolbutton.py
@@ -36,7 +36,7 @@ class TestToggleToolButton(unittest.TestCase):
         """Test basic toggle tool button creation."""
         self.assertIsInstance(self.button, ToggleToolButton)
         self.assertIsInstance(self.button, Gtk.ToggleButton)
-        self.assertIsNotNone(self.button._palette_invoker)
+        self.assertIsNotNone(self.button.get_palette_invoker())
 
     def test_toggletoolbutton_creation_with_icon(self):
         """Test toggle tool button creation with icon name."""
@@ -224,7 +224,7 @@ class TestToggleToolButtonAccelerator(unittest.TestCase):
     def test_setup_accelerator_function(self):
         """Test setup_accelerator function."""
         button = ToggleToolButton()
-        button._accelerator = "<Ctrl>T"
+        button.set_accelerator("<Ctrl>T")
         # Should work even without proper toplevel window
         self.assertTrue(True)  # If we get here, no exception was raised
 
@@ -235,7 +235,7 @@ class TestToggleToolButtonAccelerator(unittest.TestCase):
         window.sugar_accel_group = {}  # Mock accelerator group for GTK4
 
         button = ToggleToolButton()
-        button._accelerator = "<Ctrl>T"
+        button.set_accelerator("<Ctrl>T")
 
         # Add button to window
         window.set_child(button)
@@ -246,7 +246,7 @@ class TestToggleToolButtonAccelerator(unittest.TestCase):
     def test_accelerator_without_window(self):
         """Test accelerator setup without proper window."""
         button = ToggleToolButton()
-        button._accelerator = "<Ctrl>T"
+        button.set_accelerator("<Ctrl>T")
 
     def test_accelerator_parsing(self):
         """Test accelerator string parsing."""

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -196,7 +196,7 @@ class TestToolbox(unittest.TestCase):
         self.toolbox.add_toolbar("Single", toolbar)
 
         # With single toolbar, tabs should not be shown
-        notebook = self.toolbox._notebook
+        notebook = self.toolbox.get_notebook()
         self.assertFalse(notebook.get_show_tabs())
 
     def test_multiple_toolbar_tabs_shown(self):
@@ -207,7 +207,7 @@ class TestToolbox(unittest.TestCase):
         self.toolbox.add_toolbar("First", toolbar1)
 
         # Still only one toolbar
-        notebook = self.toolbox._notebook
+        notebook = self.toolbox.get_notebook()
         self.assertFalse(notebook.get_show_tabs())
 
         # Add second toolbar
@@ -218,8 +218,8 @@ class TestToolbox(unittest.TestCase):
 
     def test_toolbox_styling(self):
         """Test that toolbox has correct CSS classes."""
-        notebook = self.toolbox._notebook
-        separator = self.toolbox._separator
+        notebook = self.toolbox.get_notebook()
+        separator = self.toolbox.get_separator()
 
         self.assertTrue(notebook.has_css_class("toolbox"))
         self.assertTrue(separator.has_css_class("toolbox-separator"))

--- a/tests/test_toolcombobox.py
+++ b/tests/test_toolcombobox.py
@@ -50,23 +50,23 @@ class TestToolComboBox(unittest.TestCase):
         self.assertEqual(tool_combo.combo, custom_combo)
 
         # Should have the item from custom combo
-        self.assertEqual(len(tool_combo.combo._model), 1)
+        self.assertEqual(tool_combo.combo.get_item_count(), 1)
 
     def test_label_text_property(self):
         """Test label text property setting."""
         # Test initial empty label
-        self.assertEqual(self.tool_combo._label_text, "")
+        self.assertEqual(self.tool_combo.get_label_text(), "")
         self.assertEqual(self.tool_combo.label.get_text(), "")
 
         # Test setting via new API method
         self.tool_combo.set_label_text("Test Label")
-        self.assertEqual(self.tool_combo._label_text, "Test Label")
+        self.assertEqual(self.tool_combo.get_label_text(), "Test Label")
         self.assertEqual(self.tool_combo.label.get_text(), "Test Label")
 
     def test_label_text_property_kwargs(self):
         """Test label text property via constructor kwargs."""
         tool_combo = ToolComboBox(label_text="Constructor Label")
-        self.assertEqual(tool_combo._label_text, "Constructor Label")
+        self.assertEqual(tool_combo.get_label_text(), "Constructor Label")
         self.assertEqual(tool_combo.label.get_text(), "Constructor Label")
 
     def test_margin_setting(self):
@@ -140,7 +140,7 @@ class TestToolComboBox(unittest.TestCase):
             # Test setting label-text property
             pspec = MockPSpec("label-text")
             self.tool_combo.do_set_property(pspec, "New Label")
-            self.assertEqual(self.tool_combo._label_text, "New Label")
+            self.assertEqual(self.tool_combo.get_label_text(), "New Label")
             self.assertEqual(self.tool_combo.label.get_text(), "New Label")
         except AttributeError:
             # Method might not exist in simplified version
@@ -178,7 +178,7 @@ class TestToolComboBox(unittest.TestCase):
 
         for label_text in labels:
             self.tool_combo.set_label_text(label_text)
-            self.assertEqual(self.tool_combo._label_text, label_text)
+            self.assertEqual(self.tool_combo.get_label_text(), label_text)
             self.assertEqual(self.tool_combo.label.get_text(), label_text)
 
     def test_combo_signals(self):
@@ -252,7 +252,7 @@ class TestToolComboBoxIntegration(unittest.TestCase):
         tool_combo = ToolComboBox(combo=custom_combo, label_text="Custom:")
 
         # Should have all the items
-        self.assertEqual(len(tool_combo.combo._model), 4)
+        self.assertEqual(tool_combo.combo.get_item_count(), 4)
 
         # Test selection (set to index 3 to skip separator at index 2)
         tool_combo.combo.set_active(3)  # Skip separator

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -31,6 +31,9 @@ class MockActivity:
         self._signals = {}
         self._stop_buttons = []
 
+    def get_stop_buttons(self):
+        return self._stop_buttons
+
     def connect(self, signal, callback):
         if signal not in self._signals:
             self._signals[signal] = []
@@ -87,7 +90,7 @@ class TestActivityWidgets(unittest.TestCase):
         self.assertIsNotNone(button)
         self.assertEqual(button.props.tooltip, "Stop")
         self.assertEqual(button.props.accelerator, "<Ctrl>Q")
-        self.assertIn(button, self.activity._stop_buttons)
+        self.assertIn(button, self.activity.get_stop_buttons())
 
     def test_edit_buttons_creation(self):
         """Test edit buttons can be created."""

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -67,9 +67,9 @@ def test_window_alert_add_remove(gtk_app):
     win = Window(application=gtk_app)
     alert = Gtk.Label(label="Alert")
     win.add_alert(alert)
-    assert alert in win._alerts
+    assert alert in win.get_alerts()
     win.remove_alert(alert)
-    assert alert not in win._alerts
+    assert alert not in win.get_alerts()
 
 
 def test_window_enable_fullscreen_mode_property(gtk_app):


### PR DESCRIPTION
Fixes #7

### Summary

Tests were accessing private attributes directly. This PR adds public accessor methods so tests use proper public API.

### Progress

- [x] test_toolcombobox.py — 7 usages fixed
- [x] test_combobox.py — 34 usages fixed
- [x] test_alert.py — 9 usages fixed
- [x] test_datastore.py — 6 usages fixed
- [x] test_activity.py — 15 usages fixed
- [x] test_objectchooser.py — 14 usages fixed
- [x] test_palette.py — 3 usages fixed
- [x] test_toggletoolbutton.py — 4 usages fixed
- [x] test_window.py — 2 usages fixed
- [x] test_palettegroup.py — 4 usages fixed
- [x] test_toolbox.py — 4 usages fixed
- [x] test_widgets.py — 1 usage fixed

### Testing

All existing tests pass. No regressions.