### PR TITLE
Fix NameError in tray.py: Import Graphene

### DIFF
--- a/src/sugar4/graphics/tray.py
+++ b/src/sugar4/graphics/tray.py
@@ -29,7 +29,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Gdk", "4.0")
 
-from gi.repository import GObject, Gtk, Gdk
+from gi.repository import GObject, Gtk, Gdk, Graphene
 import logging
 from sugar4.graphics import style
 from sugar4.graphics.palette import ToolInvoker


### PR DESCRIPTION
### Summary
Fixes a runtime crash in `sugar4.graphics.tray` where `Graphene` was being used but not imported.

### The Bug
The method `do_snapshot` calls `Graphene.Rect().init(...)`, but `Graphene` was missing from the `gi.repository` imports. This would cause a `NameError` whenever the tray palette attempted to render a snapshot.

### The Fix
Added `Graphene` to the import list in `src/sugar4/graphics/tray.py`.