### PR TITLE
Fix year calculation typo in util.py

### DIFF
--- a/src/sugar4/util.py
+++ b/src/sugar4/util.py
@@ -215,7 +215,7 @@ class LRU:
         return list(self.d.keys())
 
 
-units = [['%d year', '%d years', 356 * 24 * 60 * 60],
+units = [['%d year', '%d years', 365 * 24 * 60 * 60],
          ['%d month', '%d months', 30 * 24 * 60 * 60],
          ['%d week', '%d weeks', 7 * 24 * 60 * 60],
          ['%d day', '%d days', 24 * 60 * 60],


### PR DESCRIPTION
### Summary
Fixes a logic error in `sugar4.util` where the number of days in a year was incorrect.

### The Bug
The time unit list defined a year as `356` days instead of `365`. This caused time formatting strings (e.g., "X years ago") to be mathematically inaccurate by approximately 2.5% (missing 9 days per year).

### The Fix
Corrected the constant `356` to `365` in `src/sugar4/util.py`.