### PR TITLE
Fix(graphics): remove deprecated IconLookupFlags usage

### DIFF
--- a/src/sugar4/graphics/icon.py
+++ b/src/sugar4/graphics/icon.py
@@ -249,7 +249,7 @@ class _IconBuffer:
                 self.width,
                 1,
                 Gtk.TextDirection.NONE,
-                Gtk.IconLookupFlags.NONE,
+                0,
             )
 
             if icon_paintable:

--- a/src/sugar4/graphics/iconentry.py
+++ b/src/sugar4/graphics/iconentry.py
@@ -99,7 +99,7 @@ class IconEntry(Gtk.Entry):
             _ICON_SIZE,
             1,
             Gtk.TextDirection.NONE,
-            Gtk.IconLookupFlags.NONE,
+            0,
         )
 
         if not icon_paintable:


### PR DESCRIPTION
This fixes a crash when launching activities. Gtk.IconLookupFlags was removed in GTK4, so using Gtk.IconLookupFlags.NONE was causing an AttributeError.

I've replaced it with 0, which is the correct integer value for no flags.

**Error Log:**
```text
Traceback (most recent call last):
  File ".../log-activity/logviewer.py", line 505, in _build_toolbox
    self.search_entry.set_icon_from_name(
  File ".../src/sugar4/graphics/iconentry.py", line 102, in set_icon_from_name
    Gtk.IconLookupFlags.NONE,
    ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'IconLookupFlags' has no attribute 'NONE'