### PR TITLE
Fix save() data loss after copy() — correct DSObject detection

### DIFF
--- a/src/sugar4/activity/activity.py
+++ b/src/sugar4/activity/activity.py
@@ -1040,12 +1040,9 @@ class Activity(Window):
                 self._jobject.file_path = file_path
 
         # Check if we have a real datastore object or a mock
-        if hasattr(self._jobject, "object_id") and self._jobject.object_id is not None:
-            # Real journal object - try to write to datastore
+        if isinstance(self._jobject, datastore.DSObject):
             try:
-                if self._jobject.object_id is None:
-                    datastore.write(self._jobject, transfer_ownership=True)
-                else:
+                if self._jobject.object_id:
                     self._updating_jobject = True
                     datastore.write(
                         self._jobject,
@@ -1053,6 +1050,8 @@ class Activity(Window):
                         reply_handler=self.__save_cb,
                         error_handler=self.__save_error_cb,
                     )
+                else:
+                    datastore.write(self._jobject, transfer_ownership=True)
             except Exception as e:
                 logging.warning("Failed to save to datastore: %s", e)
                 logging.info(


### PR DESCRIPTION
### **Description**

While testing the "Keep in Journal" workflow in Sugar Toolkit (GTK4), I noticed that `Activity.save()` was silently discarding all writes after `Activity.copy()` was called.

The root cause was an incorrect guard condition at line 1043:

```python
if hasattr(self._jobject, "object_id") and self._jobject.object_id
```
 is not None.
 This check used object_id is not None to distinguish real DSObject instances from standalone-mode MockJobject instances. However, Activity.copy() intentionally sets object_id = None to prepare for new-entry creation. After this, every subsequent save() call failed the guard and fell through to the "standalone mode" branch — logging success but never writing to the datastore.
 
 ---
 
### **The fix:**

- Changed the guard to isinstance(self._jobject, datastore.DSObject) — the correct discriminator
- Collapsed the dead inner branch (if self._jobject.object_id is None:) into proper sync/async dispatch
- Real DSObject instances (including post-copy() state) now correctly reach datastore.write()
- MockJobject instances still correctly route to standalone logging

---

### **Testing:**

- [x] Launch Write activity, create document, click "Keep in Journal", edit more, close — verify both entries exist in Journal
- [x] Launch activity in standalone mode (outside Sugar) — verify standalone log message still appears
- [x] Verify title changes after copy() are persisted (triggers save() via TitleEntry)
- [x] All existing tests pass