### PR TITLE
Fix GTK4 migration: replace Gtk.IconLookupFlags.NONE with Gtk.IconLookupFlags(0) 

### DIFF
--- a/src/sugar4/graphics/icon.py
+++ b/src/sugar4/graphics/icon.py
@@ -249,7 +249,7 @@ class _IconBuffer:
                 self.width,
                 1,
                 Gtk.TextDirection.NONE,
-                Gtk.IconLookupFlags(0), 
+                Gtk.IconLookupFlags(0),
             )
 
             if icon_paintable:

--- a/src/sugar4/graphics/icon.py
+++ b/src/sugar4/graphics/icon.py
@@ -1004,7 +1004,7 @@ def get_icon_file_name(icon_name: str) -> Optional[str]:
         STANDARD_ICON_SIZE,
         1,
         Gtk.TextDirection.NONE,
-        Gtk.IconLookupFlags(0), 
+        Gtk.IconLookupFlags(0),
     )
 
     if icon_paintable:

--- a/src/sugar4/graphics/icon.py
+++ b/src/sugar4/graphics/icon.py
@@ -249,7 +249,7 @@ class _IconBuffer:
                 self.width,
                 1,
                 Gtk.TextDirection.NONE,
-                Gtk.IconLookupFlags.NONE,
+                Gtk.IconLookupFlags(0), 
             )
 
             if icon_paintable:
@@ -300,7 +300,7 @@ class _IconBuffer:
             size,
             1,
             Gtk.TextDirection.NONE,
-            Gtk.IconLookupFlags.NONE,
+            Gtk.IconLookupFlags(0),
         )
 
         if not badge_paintable:
@@ -1004,7 +1004,7 @@ def get_icon_file_name(icon_name: str) -> Optional[str]:
         STANDARD_ICON_SIZE,
         1,
         Gtk.TextDirection.NONE,
-        Gtk.IconLookupFlags.NONE,
+        Gtk.IconLookupFlags(0), 
     )
 
     if icon_paintable:

--- a/src/sugar4/graphics/iconentry.py
+++ b/src/sugar4/graphics/iconentry.py
@@ -99,7 +99,7 @@ class IconEntry(Gtk.Entry):
             _ICON_SIZE,
             1,
             Gtk.TextDirection.NONE,
-            Gtk.IconLookupFlags.NONE,
+            Gtk.IconLookupFlags(0),
         )
 
         if not icon_paintable:


### PR DESCRIPTION
During the `pytest` run, 15 tests failed due to recurring issues related to the GTK4 migration.

**Error:** `AttributeError: type object 'IconLookupFlags' has no attribute 'NONE'`

`Gtk.IconLookupFlags.NONE` is not available in the current GTK Python bindings. Replaced it with `Gtk.IconLookupFlags(0)`, which explicitly represents an enum value with no flags set. This change resolves all 15 failing tests.

