### PR TITLE
fix: initialize _buffer before super().__init__ in Icon

### DIFF
--- a/src/sugar4/graphics/icon.py
+++ b/src/sugar4/graphics/icon.py
@@ -583,9 +583,9 @@ class Icon(Gtk.Widget):
         pixel_size: int = STANDARD_ICON_SIZE,
         **kwargs,
     ):
-        super().__init__(**kwargs)
-
         self._buffer = _IconBuffer()
+
+        super().__init__(**kwargs)
         self._buffer.icon_name = icon_name
         self._buffer.file_name = file_name
         self._buffer.width = pixel_size


### PR DESCRIPTION
## Problem

`Icon` property setters (`set_fill_color`, `set_stroke_color`, etc.) access `self._buffer`, but `_buffer` was initialized *after* `super().__init__(**kwargs)`. When GObject fires these setters during construction, it crashes:

AttributeError: 'Icon' object has no attribute '_buffer'


## Fix

Move `self._buffer = _IconBuffer()` before `super().__init__(**kwargs)`.
