### PR TITLE
Fixes in sugar-toolkit-gtk4 to support sugar shell migration

### DIFF
--- a/bin/sugar-activity
+++ b/bin/sugar-activity
@@ -1,5 +1,8 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
-from sugar3.activity import activityinstance
+import gi
+gi.require_version('Gtk', '4.0')
+
+from sugar4.activity import activityinstance
 
 activityinstance.main()

--- a/bin/sugar-activity-web
+++ b/bin/sugar-activity-web
@@ -17,4 +17,4 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-exec sugar-activity3 sugar3.activity.webactivity.WebActivity $@
+exec sugar-activity3 sugar4.activity.webactivity.WebActivity $@

--- a/bin/sugar-activity3
+++ b/bin/sugar-activity3
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
-from sugar3.activity import activityinstance
+import gi
+gi.require_version('Gtk', '4.0')
+
+from sugar4.activity import activityinstance
 
 activityinstance.main()

--- a/src/sugar4/__init__.py
+++ b/src/sugar4/__init__.py
@@ -25,39 +25,28 @@ try:
     gi.require_version("GLib", "2.0")
     gi.require_version("Pango", "1.0")
     gi.require_version("GdkPixbuf", "2.0")
-except ImportError:
-    # gi might not be available during docs build
-    pass
+    
+    from .activity.activity import Activity, SimpleActivity
+    from .graphics import style
+    from .graphics.icon import EventIcon, Icon
+    from .graphics.menuitem import MenuItem, MenuSeparator
+    from .graphics.xocolor import XoColor
+
+    __all__ = [
+        "Activity",
+        "SimpleActivity",
+        "XoColor",
+        "Icon",
+        "EventIcon",
+        "MenuItem",
+        "MenuSeparator",
+        "style",
+    ]
+except (ImportError, ValueError):
+    # gi might not be available during docs build,
+    # or GTK 3.0 is already loaded by a legacy activity importing a utility module.
+    __all__ = []
 
 __version__ = "1.1.4"
 __author__ = "Sugar Labs Community"
 __license__ = "LGPL-2.1-or-later"
-
-from .activity.activity import Activity, SimpleActivity
-
-# from .graphics.toolbox import Toolbox
-from .graphics import style
-from .graphics.icon import EventIcon, Icon
-
-# from .graphics.tray import HTray, VTray, TrayButton, TrayIcon
-# from .graphics.window import Window, UnfullscreenButton
-from .graphics.menuitem import MenuItem, MenuSeparator
-from .graphics.xocolor import XoColor
-
-__all__ = [
-    "Activity",
-    "SimpleActivity",
-    "XoColor",
-    "Icon",
-    "EventIcon",
-    # "HTray",
-    # "VTray",
-    # "TrayButton",
-    # "TrayIcon",
-    # "Window",
-    # "UnfullscreenButton",
-    "MenuItem",
-    "MenuSeparator",
-    # "Toolbox",
-    "style",
-]

--- a/src/sugar4/__main__.py
+++ b/src/sugar4/__main__.py
@@ -1,4 +1,4 @@
-"""Main entry point for sugar-toolkit-gtk4."""
+﻿"""Main entry point for sugar-toolkit-gtk4."""
 
 import sys
 
@@ -9,7 +9,6 @@ print = debug_print
 
 
 def main():
-    # NOTE: Following is subject to change in future versions
     """Main entry point for testing the toolkit."""
     print("Sugar Toolkit GTK4 Python")
     print("=" * 25)

--- a/src/sugar4/activity/activity.py
+++ b/src/sugar4/activity/activity.py
@@ -1,4 +1,4 @@
-﻿# Copyright (C) 2006-2007 Red Hat, Inc.
+# Copyright (C) 2006-2007 Red Hat, Inc.
 # Copyright (C) 2007-2009 One Laptop Per Child
 # Copyright (C) 2010 Collabora Ltd. <http://www.collabora.co.uk/>
 # Copyright (C) 2025 MostlyK
@@ -1338,7 +1338,7 @@ class Activity(Window):
 
     def _complete_close(self):
         """Complete the close process."""
-        self.destroy()
+        self.close()
 
         if self.shared_activity:
             self.shared_activity.leave()

--- a/src/sugar4/activity/activity.py
+++ b/src/sugar4/activity/activity.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2006-2007 Red Hat, Inc.
+﻿# Copyright (C) 2006-2007 Red Hat, Inc.
 # Copyright (C) 2007-2009 One Laptop Per Child
 # Copyright (C) 2010 Collabora Ltd. <http://www.collabora.co.uk/>
 # Copyright (C) 2025 MostlyK
@@ -173,6 +173,7 @@ gi.require_version("Gdk", "4.0")
 gi.require_version("GLib", "2.0")
 gi.require_version("GObject", "2.0")
 gi.require_version("Gio", "2.0")
+gi.require_version("Graphene", "1.0")
 
 from gi.repository import Gdk, Gio, GLib, GObject, Graphene, Gtk
 
@@ -246,7 +247,6 @@ class _ActivitySession(GObject.GObject):
 
         if len(self._activities) == 0:
             logging.debug("Quitting the activity process.")
-            # In GTK4, we need to quit the application properly
             if self._main_loop and self._main_loop.is_running():
                 self._main_loop.quit()
             else:
@@ -367,7 +367,6 @@ class Activity(Window):
                 "gtk-font-name", "%s %f" % (style.FONT_FACE, style.FONT_SIZE)
             )
 
-        # Initialize parent Window
         Window.__init__(self, application=application)
 
         if "SUGAR_ACTIVITY_ROOT" in os.environ:
@@ -392,7 +391,6 @@ class Activity(Window):
         self._session.connect("quit-requested", self.__session_quit_requested_cb)
         self._session.connect("quit", self.__session_quit_cb)
 
-        # GTK4: Accelerator groups are handled differently
         # We'll use application accelerators instead
         self.sugar_accel_group = None
         if application:
@@ -459,7 +457,6 @@ class Activity(Window):
             self._jobject_old = self._jobject
             self._jobject = datastore.copy(self._jobject, "/")
 
-        # Set the original title again after any operations
         self._original_title = self._jobject.metadata["title"]
 
     def add_stop_button(self, button):
@@ -524,7 +521,6 @@ class Activity(Window):
             jobject.file_path = ""
 
             # Try to write to datastore
-            # NOTE: Bug on GTK3 Toolkit:
             # FIXME: We should be able to get an ID synchronously from the DS,
             # then call async the actual create.
             # http://bugs.sugarlabs.org/ticket/2169
@@ -920,7 +916,6 @@ class Activity(Window):
             if renderer is None:
                 return None
 
-            # GTK4: WidgetPaintable captures any widget's current
             # rendered state, including all children.
             paintable = Gtk.WidgetPaintable.new(self.canvas)
             snapshot = Gtk.Snapshot()
@@ -1023,7 +1018,6 @@ class Activity(Window):
 
         preview = self.get_preview()
         if preview is not None:
-            # In GTK4, we handle binary data differently
             self.metadata["preview"] = preview
 
         if not self.metadata.get("activity_id", ""):
@@ -1269,7 +1263,6 @@ class Activity(Window):
             Gtk.ResponseType.CANCEL, _("Cancel"), Icon(icon_name="dialog-cancel")
         )
 
-        # GTK4: Accelerators are handled differently
         if self.sugar_accel_group and hasattr(
             self.sugar_accel_group, "set_accels_for_action"
         ):
@@ -1463,7 +1456,6 @@ class Activity(Window):
             self.unbusy()
         """
         if self._busy_count == 0:
-            # GTK4: Different cursor handling
             cursor = Gdk.Cursor.new_from_name("wait", None)
             self.set_cursor(cursor)
         self._busy_count += 1

--- a/src/sugar4/activity/activityfactory.py
+++ b/src/sugar4/activity/activityfactory.py
@@ -1,0 +1,372 @@
+# Copyright (C) 2006-2007 Red Hat, Inc.
+# Copyright (C) 2010 Collabora Ltd. <http://www.collabora.co.uk/>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+"""Shell side object which manages request to start activity
+
+UNSTABLE. Activities are currently not allowed to run other activities so at
+the moment there is no reason to stabilize this API.
+"""
+
+import logging
+import dbus
+from gi.repository import GObject
+from gi.repository import GLib
+
+from sugar4.activity.activityhandle import ActivityHandle
+from sugar4 import util
+from sugar4 import env
+from sugar4.datastore import datastore
+
+from errno import EEXIST, ENOSPC
+
+import os
+import subprocess
+
+_SHELL_SERVICE = 'org.laptop.Shell'
+_SHELL_PATH = '/org/laptop/Shell'
+_SHELL_IFACE = 'org.laptop.Shell'
+
+_ACTIVITY_FACTORY_INTERFACE = 'org.laptop.ActivityFactory'
+
+# helper method to close all filedescriptors
+# borrowed from subprocess.py
+try:
+    MAXFD = os.sysconf('SC_OPEN_MAX')
+except ValueError:
+    MAXFD = 256
+
+_compositor_fd_getter = None
+
+
+def set_compositor_fd_getter(getter):
+    global _compositor_fd_getter
+    _compositor_fd_getter = getter
+
+
+def _close_fds():
+    for i in range(3, MAXFD):
+        try:
+            os.close(i)
+        # pylint: disable=W0704
+        except Exception:
+            pass
+
+
+def create_activity_id():
+    """Generate a new, unique ID for this activity"""
+    return util.unique_id()
+
+
+def _mkdir(path):
+    try:
+        os.mkdir(path)
+    except OSError as e:
+        if e.errno != EEXIST:
+            raise e
+
+
+def get_environment(activity):
+    environ = os.environ.copy()
+
+    bin_path = os.path.join(activity.get_path(), 'bin')
+
+    activity_root = env.get_profile_path(activity.get_bundle_id())
+    _mkdir(activity_root)
+
+    instance_dir = os.path.join(activity_root, 'instance')
+    _mkdir(instance_dir)
+
+    data_dir = os.path.join(activity_root, 'data')
+    _mkdir(data_dir)
+
+    tmp_dir = os.path.join(activity_root, 'tmp')
+    _mkdir(tmp_dir)
+
+    environ['SUGAR_BUNDLE_PATH'] = activity.get_path()
+    environ['SUGAR_BUNDLE_ID'] = activity.get_bundle_id()
+    environ['SUGAR_ACTIVITY_ROOT'] = activity_root
+    environ['PATH'] = bin_path + ':' + environ['PATH']
+
+    if activity.get_path().startswith(env.get_user_activities_path()):
+        environ['SUGAR_LOCALEDIR'] = os.path.join(activity.get_path(),
+                                                  'locale')
+
+    return environ
+
+
+def get_command(activity, activity_id=None, object_id=None, uri=None,
+                activity_invite=False):
+    if not activity_id:
+        activity_id = create_activity_id()
+
+    command = activity.get_command().split(' ')
+    command.extend(['-b', activity.get_bundle_id()])
+    command.extend(['-a', activity_id])
+
+    if object_id is not None:
+        command.extend(['-o', object_id])
+    if uri is not None:
+        command.extend(['-u', uri])
+    if activity_invite:
+        command.append('-i')
+
+    # if the command is in $BUNDLE_ROOT/bin, execute the absolute path so there
+    # is no need to mangle with the shell's PATH
+    if '/' not in command[0]:
+        bin_path = os.path.join(activity.get_path(), 'bin')
+        absolute_path = os.path.join(bin_path, command[0])
+        if os.path.exists(absolute_path):
+            command[0] = absolute_path
+
+    logging.debug('launching: %r' % command)
+
+    return command
+
+
+def open_log_file(activity):
+    i = 1
+    while True:
+        path = env.get_logs_path('%s-%s.log' % (activity.get_bundle_id(), i))
+        try:
+            fd = os.open(path, os.O_EXCL | os.O_CREAT | os.O_WRONLY, 0o644)
+            f = os.fdopen(fd, 'w')
+            return (path, f)
+        except OSError as e:
+            if e.errno == EEXIST:
+                i += 1
+            elif e.errno == ENOSPC:
+                # not the end of the world; let's try to keep going.
+                return (os.devnull, open(os.devnull, 'w'))
+            else:
+                raise e
+
+
+class ActivityCreationHandler(GObject.GObject):
+    """Sugar-side activity creation interface
+
+    This object uses a dbus method on the ActivityFactory
+    service to create the new activity.  It generates
+    GObject events in response to the success/failure of
+    activity startup using callbacks to the service's
+    create call.
+    """
+
+    def __init__(self, bundle, handle):
+        """Initialise the handler
+
+        bundle -- the ActivityBundle to launch
+        activity_handle -- stores the values which are to
+            be passed to the service to uniquely identify
+            the activity to be created and the sharing
+            service that may or may not be connected with it
+
+            sugar4.activity.activityhandle.ActivityHandle instance
+
+        calls the "create" method on the service for this
+        particular activity type and registers the
+        _reply_handler and _error_handler methods on that
+        call's results.
+
+        The specific service which creates new instances of this
+        particular type of activity is created during the activity
+        registration process in shell bundle registry which creates
+        service definition files for each registered bundle type.
+
+        If the file '/etc/olpc-security' exists, then activity launching
+        will be delegated to the prototype 'Rainbow' security service.
+        """
+        super().__init__()
+
+        self._bundle = bundle
+        self._service_name = bundle.get_bundle_id()
+        self._handle = handle
+
+        bus = dbus.SessionBus()
+        bus_object = bus.get_object(_SHELL_SERVICE, _SHELL_PATH)
+        self._shell = dbus.Interface(bus_object, _SHELL_IFACE)
+
+        if handle.activity_id is not None and handle.object_id is None:
+            datastore.find({'activity_id': self._handle.activity_id},
+                           reply_handler=self._find_object_reply_handler,
+                           error_handler=self._find_object_error_handler)
+        else:
+            self._launch_activity()
+
+    def _launch_activity(self):
+        if self._handle.activity_id is not None:
+            self._shell.ActivateActivity(
+                self._handle.activity_id,
+                reply_handler=self._activate_reply_handler,
+                error_handler=self._activate_error_handler)
+        else:
+            self._create_activity()
+
+    def _create_activity(self):
+        if self._handle.activity_id is None:
+            self._handle.activity_id = create_activity_id()
+
+        self._shell.NotifyLaunch(
+            self._service_name, self._handle.activity_id,
+            reply_handler=self._no_reply_handler,
+            error_handler=self._notify_launch_error_handler)
+
+        environ = get_environment(self._bundle)
+        (log_path, log_file) = open_log_file(self._bundle)
+        command = get_command(self._bundle, self._handle.activity_id,
+                              self._handle.object_id, self._handle.uri,
+                              self._handle.invited)
+
+        pass_fds = ()
+        fd = -1
+        if _compositor_fd_getter is not None:
+            fd = _compositor_fd_getter()
+            if fd >= 0:
+                environ['WAYLAND_SOCKET'] = str(fd)
+                environ['WAYLAND_DISPLAY'] = os.environ.get('WAYLAND_DISPLAY', 'wayland-0')
+                pass_fds = (fd,)
+
+        kwargs = {
+            'env': environ,
+            'cwd': str(self._bundle.get_path()),
+            'stdout': log_file.fileno(),
+            'stderr': log_file.fileno()
+        }
+
+        if pass_fds:
+            kwargs['pass_fds'] = pass_fds
+
+        with open(os.devnull, 'r') as dev_null:
+            kwargs['stdin'] = dev_null.fileno()
+            child = subprocess.Popen([str(s) for s in command], **kwargs)
+
+        if fd >= 0:
+            os.close(fd)
+
+        GLib.child_watch_add(GLib.PRIORITY_DEFAULT, child.pid,
+                             _child_watch_cb,
+                             (log_file, self._handle.activity_id))
+
+    def _no_reply_handler(self, *args):
+        pass
+
+    def _notify_launch_failure_error_handler(self, err):
+        logging.error('Notify launch failure failed %s' % err)
+
+    def _notify_launch_error_handler(self, err):
+        logging.debug('Notify launch failed %s' % err)
+
+    def _activate_reply_handler(self, activated):
+        if not activated:
+            self._create_activity()
+
+    def _activate_error_handler(self, err):
+        logging.error('Activity activation request failed %s' % err)
+
+    def _create_reply_handler(self):
+        logging.debug('Activity created %s (%s).' %
+                      (self._handle.activity_id, self._service_name))
+
+    def _create_error_handler(self, err):
+        logging.error("Couldn't create activity %s (%s): %s" %
+                      (self._handle.activity_id, self._service_name, err))
+        self._shell.NotifyLaunchFailure(
+            self._handle.activity_id, reply_handler=self._no_reply_handler,
+            error_handler=self._notify_launch_failure_error_handler)
+
+    def _find_object_reply_handler(self, jobjects, count):
+        if count > 0:
+            if count > 1:
+                logging.debug('Multiple objects has the same activity_id.')
+            self._handle.object_id = jobjects[0]['uid']
+        self._launch_activity()
+
+    def _find_object_error_handler(self, err):
+        logging.error('Datastore find failed %s' % err)
+        self._launch_activity()
+
+
+def create(bundle, activity_handle=None):
+    """Create a new activity from its name."""
+    if not activity_handle:
+        activity_handle = ActivityHandle()
+    return ActivityCreationHandler(bundle, activity_handle)
+
+
+def create_with_uri(bundle, uri):
+    """Create a new activity and pass the uri as handle."""
+    activity_handle = ActivityHandle(uri=uri)
+    return ActivityCreationHandler(bundle, activity_handle)
+
+
+def create_with_object_id(bundle, object_id):
+    """Create a new activity and pass the object id as handle."""
+    activity_handle = ActivityHandle(object_id=object_id)
+    return ActivityCreationHandler(bundle, activity_handle)
+
+
+def _child_watch_cb(pid, condition, user_data):
+    log_file, activity_id = user_data
+
+    if os.WIFEXITED(condition):
+        status = os.WEXITSTATUS(condition)
+        signum = None
+        if status == 0:
+            message = 'Normal successful completion'
+        else:
+            message = 'Exited with status %s' % status
+    elif os.WIFSIGNALED(condition):
+        status = None
+        signum = os.WTERMSIG(condition)
+        message = 'Terminated by signal %s' % signum
+    else:
+        status = None
+        signum = os.WTERMSIG(condition)
+        message = 'Undefined status with signal %s' % signum
+
+    try:
+        log_file.write(
+            '%s, pid %s activity_id %s\n' % (message, pid, activity_id))
+    finally:
+        log_file.close()
+
+    # try to reap zombies in case SIGCHLD has not been set to SIG_IGN
+    try:
+        os.waitpid(pid, 0)
+    except OSError:
+        # SIGCHLD = SIG_IGN, no zombies
+        pass
+
+    if status or signum:
+        # XXX have to recreate dbus object since we can't reuse
+        # ActivityCreationHandler's one, see
+        # https://bugs.freedesktop.org/show_bug.cgi?id=23507
+        bus = dbus.SessionBus()
+        bus_object = bus.get_object(_SHELL_SERVICE, _SHELL_PATH)
+        shell = dbus.Interface(bus_object, _SHELL_IFACE)
+
+        def reply_handler_cb(*args):
+            pass
+
+        def error_handler_cb(error):
+            logging.error('Cannot send NotifyLaunchFailure to the shell')
+
+        # TODO send launching failure but activity could already show
+        # main window, see http://bugs.sugarlabs.org/ticket/1447#comment:19
+        shell.NotifyLaunchFailure(activity_id,
+                                  reply_handler=reply_handler_cb,
+                                  error_handler=error_handler_cb)

--- a/src/sugar4/activity/activityinstance.py
+++ b/src/sugar4/activity/activityinstance.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2006-2008, Red Hat, Inc.
+﻿# Copyright (C) 2006-2008, Red Hat, Inc.
 # Copyright (C) 2025 MostlyK
 #
 # This program is free software; you can redistribute it and/or modify
@@ -202,7 +202,6 @@ def main():
         invited=options.invited,
     )
 
-    # GTK4: Gtk.Application model
     app = Gtk.Application(application_id=bundle.get_bundle_id())
 
     def on_activate(app):

--- a/src/sugar4/bundle/activitybundle.py
+++ b/src/sugar4/bundle/activitybundle.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2007, Red Hat, Inc.
+﻿# Copyright (C) 2007, Red Hat, Inc.
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -251,7 +251,6 @@ class ActivityBundle(Bundle):
                 if nelang not in nelangs:
                     nelangs.append(nelang)
 
-        # Finally, select a language
         for lang in nelangs:
             linfo_path = os.path.join("locale", lang, "activity.linfo")
             linfo_file = self.get_file(linfo_path)

--- a/src/sugar4/datastore/datastore.py
+++ b/src/sugar4/datastore/datastore.py
@@ -35,8 +35,8 @@ from sugar4 import mime
 from sugar4 import dispatch
 from sugar4.profile import get_color
 
-DS_DBUS_SERVICE = "org.laptop.sugar4.DataStore"
-DS_DBUS_INTERFACE = "org.laptop.sugar4.DataStore"
+DS_DBUS_SERVICE = "org.laptop.sugar.DataStore"
+DS_DBUS_INTERFACE = "org.laptop.sugar.DataStore"
 DS_DBUS_PATH = "/org/laptop/sugar/DataStore"
 
 _data_store = None

--- a/src/sugar4/graphics/__init__.py
+++ b/src/sugar4/graphics/__init__.py
@@ -43,6 +43,7 @@ from .iconentry import (
 # from .tray import (HTray, VTray, TrayButton, TrayIcon,
 #                    ALIGN_TO_START, ALIGN_TO_END, GRID_CELL_SIZE)
 # from .window import Window, UnfullscreenButton
+from .scrollingdetector import ScrollingDetector
 
 
 __all__ = [
@@ -60,6 +61,7 @@ __all__ = [
     "SMALL_ICON_SIZE",
     "STANDARD_ICON_SIZE",
     "LARGE_ICON_SIZE",
+    "ScrollingDetector",
     # "HTray", "VTray", "TrayButton", "TrayIcon",
     # "ALIGN_TO_START", "ALIGN_TO_END", "GRID_CELL_SIZE",
     # "Window", "UnfullscreenButton"

--- a/src/sugar4/graphics/alert.py
+++ b/src/sugar4/graphics/alert.py
@@ -58,6 +58,8 @@ from gi.repository import Gtk
 from gi.repository import GObject
 from gi.repository import GLib
 
+from gi.repository import PangoCairo
+
 from sugar4.graphics import style
 from sugar4.graphics.icon import Icon
 
@@ -106,7 +108,6 @@ class Alert(Gtk.Box):
         self._icon = None
         self._buttons = {}
 
-        # Set margin and spacing (replaces border_width)
         self.set_margin_top(style.DEFAULT_SPACING)
         self.set_margin_bottom(style.DEFAULT_SPACING)
         self.set_margin_start(style.DEFAULT_SPACING)
@@ -164,8 +165,11 @@ class Alert(Gtk.Box):
                 self._msg_label.set_wrap(True)
         elif pspec.name == "icon":
             if self._icon != value:
+                if self._icon is not None:
+                    self.remove(self._icon)
                 self._icon = value
-                self.prepend(self._icon)
+                if self._icon is not None:
+                    self.prepend(self._icon)
 
     def do_get_property(self, pspec):
         """
@@ -353,7 +357,7 @@ class _TimeoutIcon(Gtk.Widget):
             text_width, text_height = layout.get_pixel_size()
             cr.move_to(x - text_width / 2, y - text_height / 2)
             cr.set_source_rgba(color.red, color.green, color.blue, color.alpha)
-            layout.show_in_cairo_context(cr)
+            PangoCairo.show_layout(cr, layout)
 
     def set_text(self, text):
         self._text = str(text)

--- a/src/sugar4/graphics/alert.py
+++ b/src/sugar4/graphics/alert.py
@@ -136,7 +136,15 @@ class Alert(Gtk.Box):
         self.append(self._buttons_box)
 
         self.add_css_class("sugar-alert")
-
+        
+        css = """
+        .sugar-alert {
+            background-color: @theme_bg_color;
+            border: 2px solid @theme_fg_color;
+            border-radius: 4px;
+        }
+        """
+        style.apply_css_to_widget(self, css)
     def do_set_property(self, pspec, value):
         """
         Set alert property, GObject internal method.

--- a/src/sugar4/graphics/alert.py
+++ b/src/sugar4/graphics/alert.py
@@ -19,10 +19,8 @@ Example:
 
         from sugar4.graphics.alert import Alert
 
-        # Create a new simple alert
         alert = Alert()
 
-        # Set the title and text body of the alert
         alert.props.title = _('Title of Alert Goes Here')
         alert.props.msg = _('Text message of alert goes here')
 
@@ -139,9 +137,12 @@ class Alert(Gtk.Box):
         
         css = """
         .sugar-alert {
-            background-color: @theme_bg_color;
-            border: 2px solid @theme_fg_color;
+            background-color: black;
+            border: 2px solid #808080;
             border-radius: 4px;
+        }
+        .sugar-alert label {
+            color: white;
         }
         """
         style.apply_css_to_widget(self, css)
@@ -227,9 +228,16 @@ class Alert(Gtk.Box):
         """
         button = Gtk.Button()
         self._buttons[response_id] = button
+        
         if icon is not None:
-            button.set_child(icon)
-        button.set_label(label)
+            box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_PADDING)
+            box.append(icon)
+            text_label = Gtk.Label(label=label)
+            box.append(text_label)
+            button.set_child(box)
+        else:
+            button.set_label(label)
+            
         self._buttons_box.append(button)
         button.connect("clicked", self.__button_clicked_cb, response_id)
         return button
@@ -322,7 +330,6 @@ class _TimeoutIcon(Gtk.Widget):
         width = self.get_width()
         height = self.get_height()
 
-        # Create a cairo context from snapshot
         rect = Graphene.Rect()
         rect.init(0, 0, width, height)
         cr = snapshot.append_cairo(rect)

--- a/src/sugar4/graphics/animator.py
+++ b/src/sugar4/graphics/animator.py
@@ -149,49 +149,42 @@ class Animator(GObject.GObject):
         self._start_time = time.time()
         self._completed = False
 
-        # Using GTK4 frame clock for smoother animation
         if self._widget and hasattr(self._widget, "add_tick_callback"):
             try:
                 self._tick_callback_id = self._widget.add_tick_callback(
                     self._tick_cb, None
                 )
-                logging.debug("Using GTK4 frame clock for animation")
             except Exception as e:
                 logging.warning(
-                    f"Failed to use frame clock, falling back to timeout: {e}"
+                    "Failed to use frame clock, falling back to timeout: %s", e
                 )
                 self._use_timeout_fallback()
         else:
             self._use_timeout_fallback()
 
     def _use_timeout_fallback(self):
-        """Use GLib timeout as fallback when frame clock is not available."""
         interval_ms = int(self._interval * 1000)
         self._timeout_sid = GLib.timeout_add(interval_ms, self._timeout_cb)
-        logging.debug(f"Using timeout fallback with {interval_ms}ms interval")
 
     def stop(self):
         """
         Stop the animation and emit the `completed` signal.
         """
-        # Stop any active animation
         if self._tick_callback_id and self._widget:
             if not getattr(self, '_in_tick_cb', False):
                 try:
                     self._widget.remove_tick_callback(self._tick_callback_id)
                 except Exception as e:
-                    logging.warning(f"Error removing tick callback: {e}")
+                    logging.warning("Error removing tick callback: %s", e)
             self._tick_callback_id = 0
 
         if self._timeout_sid:
             GLib.source_remove(self._timeout_sid)
             self._timeout_sid = 0
 
-        # Call do_stop on all animations
         for animation in self._animations:
             animation.do_stop()
 
-        # Emit completed signal if not already completed
         if not self._completed:
             self._completed = True
             self.emit("completed")
@@ -363,12 +356,15 @@ class FadeAnimation(Animation):
 
 class ScaleAnimation(Animation):
     """
-    A convenience animation class for scaling widgets.
+    A convenience animation class for scaling widgets via opacity.
+
+    GTK4 Python bindings do not expose Gsk.Transform on Gtk.Widget
+    directly. This class uses opacity as a visual scale proxy.
 
     Args:
         widget (Gtk.Widget): The widget to animate
-        start_scale (float): Starting scale factor
-        end_scale (float): Ending scale factor
+        start_scale (float): Starting opacity (0.0 to 1.0)
+        end_scale (float): Ending opacity (0.0 to 1.0)
     """
 
     def __init__(self, widget, start_scale=0.0, end_scale=1.0):
@@ -376,28 +372,23 @@ class ScaleAnimation(Animation):
         self._widget = widget
 
     def next_frame(self, frame):
-        """Update widget scale."""
+        """Update widget opacity as scale proxy."""
         if self._widget:
-            # Apply scale transform
-            transform = self._widget.get_transform()
-            if transform:
-                transform = transform.scale(frame, frame)
-            else:
-                # Create new transform
-                from gi.repository import Gsk
-
-                transform = Gsk.Transform.new().scale(frame, frame)
-            self._widget.set_transform(transform)
+            self._widget.set_opacity(max(0.0, min(1.0, frame)))
 
 
 class MoveAnimation(Animation):
     """
     A convenience animation class for moving widgets.
 
+    Uses widget margin properties as a proxy for position, which is the
+    standard GTK4 Python API approach. Direct transform manipulation is
+    not exposed on Gtk.Widget in Python bindings.
+
     Args:
         widget (Gtk.Widget): The widget to animate
-        start_pos (tuple): Starting position (x, y)
-        end_pos (tuple): Ending position (x, y)
+        start_pos (tuple): Starting position (x, y) as margin offsets
+        end_pos (tuple): Ending position (x, y) as margin offsets
     """
 
     def __init__(self, widget, start_pos, end_pos):
@@ -407,16 +398,12 @@ class MoveAnimation(Animation):
         self._end_pos = end_pos
 
     def next_frame(self, frame):
-        """Update widget position."""
+        """Update widget margin position."""
         if self._widget:
-            x = self._start_pos[0] + (self._end_pos[0] - self._start_pos[0]) * frame
-            y = self._start_pos[1] + (self._end_pos[1] - self._start_pos[1]) * frame
-
-            # Apply translation transform
-            from gi.repository import Gsk
-
-            transform = Gsk.Transform.new().translate((x, y))
-            self._widget.set_transform(transform)
+            x = int(self._start_pos[0] + (self._end_pos[0] - self._start_pos[0]) * frame)
+            y = int(self._start_pos[1] + (self._end_pos[1] - self._start_pos[1]) * frame)
+            self._widget.set_margin_start(max(0, x))
+            self._widget.set_margin_top(max(0, y))
 
 
 class ColorAnimation(Animation):

--- a/src/sugar4/graphics/animator.py
+++ b/src/sugar4/graphics/animator.py
@@ -41,7 +41,6 @@ Example:
         # Construct a 5 second animator
         animator = Animator(5, widget=w)
 
-        # Create an animation subclass to animate the widget
         class SizeAnimation(Animation):
             def __init__(self):
                 # Tell the animation to give us values between 20 and
@@ -120,6 +119,7 @@ class Animator(GObject.GObject):
         self._tick_callback_id = 0
         self._start_time = None
         self._completed = False
+        self._in_tick_cb = False
 
     def add(self, animation):
         """
@@ -176,10 +176,11 @@ class Animator(GObject.GObject):
         """
         # Stop any active animation
         if self._tick_callback_id and self._widget:
-            try:
-                self._widget.remove_tick_callback(self._tick_callback_id)
-            except Exception as e:
-                logging.warning(f"Error removing tick callback: {e}")
+            if not getattr(self, '_in_tick_cb', False):
+                try:
+                    self._widget.remove_tick_callback(self._tick_callback_id)
+                except Exception as e:
+                    logging.warning(f"Error removing tick callback: {e}")
             self._tick_callback_id = 0
 
         if self._timeout_sid:
@@ -199,8 +200,17 @@ class Animator(GObject.GObject):
         """Frame clock callback for smooth animation timing."""
         if self._start_time is None:
             self._start_time = time.time()
-
-        return self._next_frame_cb()
+            
+        self._in_tick_cb = True
+        try:
+            res = self._next_frame_cb()
+        finally:
+            self._in_tick_cb = False
+            
+        if res == GLib.SOURCE_REMOVE:
+            self._tick_callback_id = 0
+            
+        return res
 
     def _timeout_cb(self):
         """GLib timeout callback."""
@@ -238,7 +248,6 @@ class Animation(object):
 
     .. code-block:: python
 
-        # Create an animation subclass
         class MyAnimation(Animation):
             def __init__(self, thing):
                 # Tell the animation to give us values between 0.0 and

--- a/src/sugar4/graphics/colorbutton.py
+++ b/src/sugar4/graphics/colorbutton.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2007, Red Hat, Inc.
+﻿# Copyright (C) 2007, Red Hat, Inc.
 # Copyright (C) 2008, Benjamin Berg <benjamin@sipsolutions.net>
 # Copyright (C) 2025 MostlyK
 #
@@ -58,7 +58,6 @@ class _ColorButton(Gtk.Button):
 
     def __init__(self, **kwargs):
         self._title = _("Choose a color")
-        # GTK4: Gdk.Color → Gdk.RGBA
         self._color = Gdk.RGBA()
         self._color.red = 0.0
         self._color.green = 0.0
@@ -76,7 +75,6 @@ class _ColorButton(Gtk.Button):
         GObject.GObject.__init__(self, **kwargs)
 
         # FIXME Drag and drop is not working, SL #3796
-        # GTK4: Drag and drop API changed significantly
         # For now, disable drag and drop
         """
         if self._accept_drag:
@@ -84,7 +82,6 @@ class _ColorButton(Gtk.Button):
             pass
         """
 
-        # GTK4: set_image → set_child
         self._preview.fill_color = get_svg_color_string(self._color)
         self._preview.stroke_color = self._get_fg_style_color_str()
         self.set_child(self._preview)
@@ -116,7 +113,6 @@ class _ColorButton(Gtk.Button):
 
     def _get_fg_style_color_str(self):
         context = self.get_style_context()
-        # GTK4: get_color with StateType -> get_color with state
         fg_color = context.get_color()
         # the color components are stored as float values between 0.0 and 1.0
         return "#%.2X%.2X%.2X" % (
@@ -269,24 +265,20 @@ class _ColorPalette(Palette):
 
         self._picker_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
 
-        # GTK4: Gtk.Alignment removed, use margins instead
         alignment = Gtk.Box()
         alignment.set_margin_start(style.DEFAULT_SPACING)
         alignment.set_margin_end(style.DEFAULT_SPACING)
         alignment.append(self._picker_hbox)
         self.set_content(alignment)
 
-        # GTK4: Gtk.Table → Gtk.Grid
         self._swatch_tray = Gtk.Grid()
 
         self._picker_hbox.append(self._swatch_tray)
-        # GTK4: Gtk.VSeparator → Gtk.Separator with orientation
         separator = Gtk.Separator(orientation=Gtk.Orientation.VERTICAL)
         self._picker_hbox.append(separator)
         self._picker_hbox.set_margin_start(style.DEFAULT_SPACING)
         self._picker_hbox.set_margin_end(style.DEFAULT_SPACING)
 
-        # GTK4: Gtk.Table → Gtk.Grid
         self._chooser_table = Gtk.Grid()
         self._chooser_table.set_column_spacing(style.DEFAULT_PADDING)
 
@@ -314,7 +306,6 @@ class _ColorPalette(Palette):
             scale.set_value(self._color.blue)
 
         scale.connect("value-changed", self.__scale_value_changed_cb, color)
-        # GTK4: Grid uses attach(child, column, row, width, height)
         self._chooser_table.attach(label, 0, row, 1, 1)
         self._chooser_table.attach(scale, 1, row, 1, 1)
 
@@ -356,7 +347,6 @@ class _ColorPalette(Palette):
                 accept_drag=False,
                 icon_size=style.STANDARD_ICON_SIZE,
             )
-            # GTK4: ReliefStyle removed, buttons are flat by default
             self._swatch_tray.attach(button, i % rows, i // rows, 1, 1)
             button.connect("clicked", self.__swatch_button_clicked_cb)
             i += 1
@@ -420,7 +410,6 @@ class _ColorPalette(Palette):
 
 def _add_accelerator(tool_button):
     """GTK4: Accelerators are now handled at the application level."""
-    # In GTK4, accelerators are set via Gtk.Application.set_accels_for_action()
     pass
 
 
@@ -447,7 +436,6 @@ class ColorToolButton(Gtk.Box):
 
         GObject.GObject.__init__(self, **kwargs)
 
-        # GTK4: Create the button and add it to the box
         self._color_button = _ColorButton(icon_name=icon_name, has_invoker=False)
         self.append(self._color_button)
 

--- a/src/sugar4/graphics/icon.py
+++ b/src/sugar4/graphics/icon.py
@@ -994,6 +994,8 @@ class CellRendererIcon(Gtk.CellRenderer):
         self._buffer = _IconBuffer()
         self._buffer.cache = True
         self._xo_color = None
+        self._fill_color = None
+        self._stroke_color = None
         self._prelit_fill_color = None
         self._prelit_stroke_color = None
         self._is_scrolling = False
@@ -1045,17 +1047,19 @@ class CellRendererIcon(Gtk.CellRenderer):
     xo_color = GObject.Property(type=object, getter=get_xo_color, setter=set_xo_color)
 
     def get_fill_color(self) -> Optional[str]:
-        return self._buffer.fill_color
+        return self._fill_color or self._buffer.fill_color
 
     def set_fill_color(self, color: Optional[str]):
+        self._fill_color = color
         self._buffer.fill_color = color
 
     fill_color = GObject.Property(type=str, getter=get_fill_color, setter=set_fill_color)
 
     def get_stroke_color(self) -> Optional[str]:
-        return self._buffer.stroke_color
+        return self._stroke_color or self._buffer.stroke_color
 
     def set_stroke_color(self, color: Optional[str]):
+        self._stroke_color = color
         self._buffer.stroke_color = color
 
     stroke_color = GObject.Property(type=str, getter=get_stroke_color, setter=set_stroke_color)

--- a/src/sugar4/graphics/icon.py
+++ b/src/sugar4/graphics/icon.py
@@ -1113,11 +1113,19 @@ class CellRendererIcon(Gtk.CellRenderer):
             finally:
                 snapshot.restore()
 
-    def do_get_size(self, widget, cell_area):
-        # Return (x_offset, y_offset, width, height)
-        # We can just return the size requested
+    def do_get_preferred_width(self, widget):
         size = self._buffer.width
-        return (0, 0, size, size)
+        return size, size
+
+    def do_get_preferred_height(self, widget):
+        size = self._buffer.width
+        return size, size
+
+    def do_get_preferred_width_for_height(self, widget, height):
+        return self.do_get_preferred_width(widget)
+
+    def do_get_preferred_height_for_width(self, widget, width):
+        return self.do_get_preferred_height(widget)
 
     def do_activate(self, event, widget, path, background_area, cell_area, flags):
         self.emit('clicked', path)

--- a/src/sugar4/graphics/icon.py
+++ b/src/sugar4/graphics/icon.py
@@ -40,6 +40,7 @@ Classes:
     get_icon_state: Utility function to get state-based icon names
 """
 
+import io
 import re
 import logging
 import os
@@ -56,6 +57,19 @@ from gi.repository import GLib, GObject, Gtk, Gdk, GdkPixbuf, Rsvg
 import cairo
 
 from sugar4.graphics.xocolor import XoColor
+
+
+def _pixbuf_to_cairo_surface(pixbuf: GdkPixbuf.Pixbuf) -> Optional[cairo.ImageSurface]:
+    """Convert GdkPixbuf to cairo ImageSurface without Gdk.cairo_set_source_pixbuf."""
+    if pixbuf is None:
+        return None
+    try:
+        success, buffer = pixbuf.save_to_bufferv("png", [], [])
+        if success and buffer:
+            return cairo.ImageSurface.create_from_png(io.BytesIO(buffer))
+    except Exception as e:
+        logging.error("Failed to convert pixbuf to cairo surface: %s", e)
+    return None
 
 
 class _LRU:
@@ -348,8 +362,9 @@ class _IconBuffer:
                 icon_width = pixbuf.get_width()
                 icon_height = pixbuf.get_height()
 
+                pb_surface = _pixbuf_to_cairo_surface(pixbuf)
                 context.scale(float(size) / icon_width, float(size) / icon_height)
-                Gdk.cairo_set_source_pixbuf(context, pixbuf, 0, 0)
+                context.set_source_surface(pb_surface, 0, 0)
 
                 if sensitive:
                     context.paint()
@@ -441,7 +456,8 @@ class _IconBuffer:
         x = (width / scale - pb_width) / 2
         y = (height / scale - pb_height) / 2
 
-        Gdk.cairo_set_source_pixbuf(ctx, pixbuf, x, y)
+        pb_surface = _pixbuf_to_cairo_surface(pixbuf)
+        ctx.set_source_surface(pb_surface, x, y)
 
         if sensitive:
             if self.alpha == 1.0:

--- a/src/sugar4/graphics/icon.py
+++ b/src/sugar4/graphics/icon.py
@@ -586,6 +586,7 @@ class Icon(Gtk.Widget):
         self._buffer = _IconBuffer()
 
         super().__init__(**kwargs)
+
         self._buffer.icon_name = icon_name
         self._buffer.file_name = file_name
         self._buffer.width = pixel_size
@@ -606,21 +607,16 @@ class Icon(Gtk.Widget):
             y = (height - surface.get_height()) / 2
 
             snapshot.save()
-            snapshot.translate(Graphene.Point().init(x, y))
-
-            # Convert surface to pixbuf then to texture
-            pixbuf = Gdk.pixbuf_get_from_surface(
-                surface, 0, 0, surface.get_width(), surface.get_height()
-            )
-            if pixbuf:
-                texture = Gdk.Texture.new_for_pixbuf(pixbuf)
-                snapshot.append_texture(
-                    texture,
-                    Graphene.Rect().init(
-                        0, 0, surface.get_width(), surface.get_height()
-                    ),
-                )
-            snapshot.restore()
+            try:
+                snapshot.translate(Graphene.Point().init(x, y))
+                bounds = Graphene.Rect().init(0, 0, surface.get_width(), surface.get_height())
+                cr = snapshot.append_cairo(bounds)
+                cr.set_source_surface(surface, 0, 0)
+                cr.paint()
+            except Exception as e:
+                logging.error("Icon snapshot failed: %s", e)
+            finally:
+                snapshot.restore()
 
     def do_measure(
         self, orientation: Gtk.Orientation, for_size: int
@@ -655,6 +651,13 @@ class Icon(Gtk.Widget):
             self._buffer.height = size
             self.set_size_request(size, size)
             self.queue_resize()
+
+    # Legacy aliases for compatibility
+    def get_size(self) -> int:
+        return self.get_pixel_size()
+
+    def set_size(self, size: int):
+        self.set_pixel_size(size)
 
     def get_fill_color(self) -> Optional[str]:
         return self._buffer.fill_color
@@ -715,6 +718,9 @@ class Icon(Gtk.Widget):
         type=str, default=None, getter=get_icon_name, setter=set_icon_name
     )
     file_name = GObject.Property(
+        type=str, default=None, getter=get_file_name, setter=set_file_name
+    )
+    file = GObject.Property(
         type=str, default=None, getter=get_file_name, setter=set_file_name
     )
     pixel_size = GObject.Property(
@@ -802,7 +808,8 @@ class EventIcon(Icon):
         # Set up gesture handling
         self._setup_gestures()
 
-        from sugar4.graphics.palettewindow import CursorInvoker
+        # Set up palette invoker (restoring GTK3 behavior)
+        from sugar4.graphics.palette import CursorInvoker, Palette
         self._palette_invoker = CursorInvoker()
         self._palette_invoker.attach(self)
 
@@ -989,7 +996,7 @@ class CanvasIcon(EventIcon):
 
 
 # Simplified cell renderer for list/tree view compatibility
-class CellRendererIcon:
+class CellRendererIcon(Gtk.CellRenderer):
     """
     Icon renderer for use in list/tree views.
 
@@ -998,32 +1005,87 @@ class CellRendererIcon:
 
     Note: Consider using modern list/tree widget patterns instead.
     """
+    __gtype_name__ = 'SugarCellRendererIcon'
 
-    def __init__(self):
+    __gsignals__ = {
+        'clicked': (GObject.SignalFlags.RUN_FIRST, None, ([str]))
+    }
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self._buffer = _IconBuffer()
         self._buffer.cache = True
         self._xo_color = None
         self._prelit_fill_color = None
         self._prelit_stroke_color = None
 
-    def set_icon_name(self, icon_name: str):
-        self._buffer.icon_name = icon_name
+    def get_icon_name(self) -> Optional[str]:
+        return self._buffer.icon_name
 
-    def set_file_name(self, file_name: str):
-        self._buffer.file_name = file_name
+    def set_icon_name(self, icon_name: Optional[str]):
+        if self._buffer.icon_name != icon_name:
+            self._buffer.icon_name = icon_name
 
-    def set_xo_color(self, xo_color: XoColor):
+    icon_name = GObject.Property(type=str, getter=get_icon_name, setter=set_icon_name)
+
+    def get_file_name(self) -> Optional[str]:
+        return self._buffer.file_name
+
+    def set_file_name(self, file_name: Optional[str]):
+        if self._buffer.file_name != file_name:
+            self._buffer.file_name = file_name
+
+    file_name = GObject.Property(type=str, getter=get_file_name, setter=set_file_name)
+    file = GObject.Property(type=str, getter=get_file_name, setter=set_file_name)
+
+    def get_xo_color(self) -> Optional[XoColor]:
+        return self._xo_color
+
+    def set_xo_color(self, xo_color: Optional[XoColor]):
         self._xo_color = xo_color
 
-    def set_fill_color(self, color: str):
+    xo_color = GObject.Property(type=object, getter=get_xo_color, setter=set_xo_color)
+
+    def get_fill_color(self) -> Optional[str]:
+        return self._buffer.fill_color
+
+    def set_fill_color(self, color: Optional[str]):
         self._buffer.fill_color = color
 
-    def set_stroke_color(self, color: str):
+    fill_color = GObject.Property(type=str, getter=get_fill_color, setter=set_fill_color)
+
+    def get_stroke_color(self) -> Optional[str]:
+        return self._buffer.stroke_color
+
+    def set_stroke_color(self, color: Optional[str]):
         self._buffer.stroke_color = color
+
+    stroke_color = GObject.Property(type=str, getter=get_stroke_color, setter=set_stroke_color)
+
+    def get_size(self) -> int:
+        return self._buffer.width
 
     def set_size(self, size: int):
         self._buffer.width = size
         self._buffer.height = size
+
+    size = GObject.Property(type=int, default=STANDARD_ICON_SIZE, getter=get_size, setter=set_size)
+
+    def get_prelit_fill_color(self) -> Optional[str]:
+        return self._prelit_fill_color
+
+    def set_prelit_fill_color(self, color: Optional[str]):
+        self._prelit_fill_color = color
+
+    prelit_fill_color = GObject.Property(type=str, getter=get_prelit_fill_color, setter=set_prelit_fill_color)
+
+    def get_prelit_stroke_color(self) -> Optional[str]:
+        return self._prelit_stroke_color
+
+    def set_prelit_stroke_color(self, color: Optional[str]):
+        self._prelit_stroke_color = color
+
+    prelit_stroke_color = GObject.Property(type=str, getter=get_prelit_stroke_color, setter=set_prelit_stroke_color)
 
     def get_surface(self, sensitive: bool = True) -> Optional[cairo.ImageSurface]:
         """Get rendered surface."""
@@ -1032,6 +1094,34 @@ class CellRendererIcon:
             self._buffer.stroke_color = self._xo_color.get_stroke_color()
 
         return self._buffer.get_surface(sensitive)
+
+    def do_snapshot(self, snapshot, widget, background_area, cell_area, flags):
+        surface = self.get_surface(True)
+        if surface:
+            x = cell_area.x + (cell_area.width - surface.get_width()) / 2
+            y = cell_area.y + (cell_area.height - surface.get_height()) / 2
+
+            snapshot.save()
+            try:
+                snapshot.translate(Graphene.Point().init(x, y))
+                bounds = Graphene.Rect().init(0, 0, surface.get_width(), surface.get_height())
+                cr = snapshot.append_cairo(bounds)
+                cr.set_source_surface(surface, 0, 0)
+                cr.paint()
+            except Exception as e:
+                logging.error("CellRendererIcon snapshot failed: %s", e)
+            finally:
+                snapshot.restore()
+
+    def do_get_size(self, widget, cell_area):
+        # Return (x_offset, y_offset, width, height)
+        # We can just return the size requested
+        size = self._buffer.width
+        return (0, 0, size, size)
+
+    def do_activate(self, event, widget, path, background_area, cell_area, flags):
+        self.emit('clicked', path)
+        return True
 
 
 # Utility functions

--- a/src/sugar4/graphics/icon.py
+++ b/src/sugar4/graphics/icon.py
@@ -206,7 +206,17 @@ class _IconBuffer:
         if self.stroke_color:
             entities["stroke_color"] = self.stroke_color
 
-        return self._loader.load(file_name, entities, self.cache)
+        # Handle Color objects
+        processed_entities = {}
+        for k, v in entities.items():
+            if hasattr(v, 'get_svg'):
+                processed_entities[k] = v.get_svg()
+            elif hasattr(v, 'get_html'):
+                processed_entities[k] = v.get_html()
+            else:
+                processed_entities[k] = v
+
+        return self._loader.load(file_name, processed_entities, self.cache)
 
     def _get_attach_points(self, file_name: str) -> Tuple[float, float]:
         """Get badge attachment points from .icon file."""
@@ -592,9 +602,6 @@ class Icon(Gtk.Widget):
         self._buffer.width = pixel_size
         self._buffer.height = pixel_size
 
-        # Set up drawing
-        self.set_size_request(pixel_size, pixel_size)
-
     def do_snapshot(self, snapshot: Gtk.Snapshot):
         """Render icon using snapshot-based drawing."""
         surface = self._buffer.get_surface(self.get_sensitive())
@@ -618,12 +625,34 @@ class Icon(Gtk.Widget):
             finally:
                 snapshot.restore()
 
+        # Snapshot any children (e.g., attached Popovers)
+        child = self.get_first_child()
+        while child:
+            self.snapshot_child(child, snapshot)
+            child = child.get_next_sibling()
+
     def do_measure(
         self, orientation: Gtk.Orientation, for_size: int
     ) -> Tuple[int, int, int, int]:
         """Calculate widget size requirements."""
+        surface = self._buffer.get_surface(self.get_sensitive())
+        if surface:
+            if orientation == Gtk.Orientation.HORIZONTAL:
+                size = surface.get_width()
+            else:
+                size = surface.get_height()
+            return size, size, -1, -1
+
         size = max(self._buffer.width, self._buffer.height)
         return size, size, -1, -1
+
+    def do_size_allocate(self, width: int, height: int, baseline: int):
+        """Allocate layout space to children."""
+        child = self.get_first_child()
+        while child:
+            if child.get_visible() and not isinstance(child, Gtk.Native):
+                child.allocate(width, height, baseline, None)
+            child = child.get_next_sibling()
 
     # Properties
     def get_icon_name(self) -> Optional[str]:
@@ -649,8 +678,8 @@ class Icon(Gtk.Widget):
         if self._buffer.width != size:
             self._buffer.width = size
             self._buffer.height = size
-            self.set_size_request(size, size)
             self.queue_resize()
+            self.queue_draw()
 
     # Legacy aliases for compatibility
     def get_size(self) -> int:
@@ -921,12 +950,6 @@ class CanvasIcon(EventIcon):
         motion_controller.connect("leave", self._on_leave)
         self.add_controller(motion_controller)
 
-        # Override click gesture to handle states
-        click_gesture = Gtk.GestureClick()
-        click_gesture.connect("pressed", self._on_canvas_pressed)
-        click_gesture.connect("released", self._on_canvas_released)
-        self.add_controller(click_gesture)
-
     def _on_enter(self, controller, x, y):
         """Handle mouse enter."""
         self.set_state_flags(Gtk.StateFlags.PRELIGHT, False)
@@ -941,24 +964,17 @@ class CanvasIcon(EventIcon):
             self.unset_state_flags(
                 Gtk.StateFlags.PRELIGHT | Gtk.StateFlags.ACTIVE)
 
-    def _on_canvas_pressed(self, gesture, n_press, x, y):
+    def _on_pressed(self, gesture, n_press, x, y):
         """Handle canvas press."""
         self._button_down = True
         self.set_state_flags(Gtk.StateFlags.ACTIVE, False)
-        self.emit("pressed", x, y)
+        super()._on_pressed(gesture, n_press, x, y)
 
-    def _on_canvas_released(self, gesture, n_press, x, y):
+    def _on_released(self, gesture, n_press, x, y):
         """Handle canvas release."""
         self.unset_state_flags(Gtk.StateFlags.ACTIVE)
         self._button_down = False
-        self.emit("released", x, y)
-
-        if n_press == 1:
-            width = self.get_width()
-            height = self.get_height()
-            if 0 <= x <= width and 0 <= y <= height:
-                self.emit("clicked")
-                self.emit("activate")
+        super()._on_released(gesture, n_press, x, y)
 
     def connect_to_palette_pop_events(self, palette):
         """Hold the prelight state while the palette is shown."""
@@ -1018,6 +1034,20 @@ class CellRendererIcon(Gtk.CellRenderer):
         self._xo_color = None
         self._prelit_fill_color = None
         self._prelit_stroke_color = None
+        self._is_scrolling = False
+
+    def connect_to_scroller(self, scrolled):
+        scrolled.connect('scroll-start', self._scroll_start_cb)
+        scrolled.connect('scroll-end', self._scroll_end_cb)
+
+    def _scroll_start_cb(self, event):
+        self._is_scrolling = True
+
+    def _scroll_end_cb(self, event):
+        self._is_scrolling = False
+
+    def is_scrolling(self):
+        return self._is_scrolling
 
     def get_icon_name(self) -> Optional[str]:
         return self._buffer.icon_name

--- a/src/sugar4/graphics/icon.py
+++ b/src/sugar4/graphics/icon.py
@@ -1035,6 +1035,12 @@ class CellRendererIcon(Gtk.CellRenderer):
 
     def set_xo_color(self, xo_color: Optional[XoColor]):
         self._xo_color = xo_color
+        if xo_color is not None:
+            self._buffer.fill_color = xo_color.get_fill_color()
+            self._buffer.stroke_color = xo_color.get_stroke_color()
+        else:
+            self._buffer.fill_color = self._fill_color
+            self._buffer.stroke_color = self._stroke_color
 
     xo_color = GObject.Property(type=object, getter=get_xo_color, setter=set_xo_color)
 
@@ -1081,9 +1087,12 @@ class CellRendererIcon(Gtk.CellRenderer):
 
     def get_surface(self, sensitive: bool = True) -> Optional[cairo.ImageSurface]:
         """Get rendered surface."""
-        if self._xo_color:
+        if self._xo_color is not None:
             self._buffer.fill_color = self._xo_color.get_fill_color()
             self._buffer.stroke_color = self._xo_color.get_stroke_color()
+        else:
+            self._buffer.fill_color = self._fill_color
+            self._buffer.stroke_color = self._stroke_color
 
         return self._buffer.get_surface(sensitive)
 

--- a/src/sugar4/graphics/icon.py
+++ b/src/sugar4/graphics/icon.py
@@ -58,7 +58,6 @@ import cairo
 from sugar4.graphics.xocolor import XoColor
 
 
-# Simple LRU cache implementation
 class _LRU:
     def __init__(self, size):
         self.size = size
@@ -89,7 +88,6 @@ class _LRU:
 _BADGE_SIZE = 0.45
 _DEFAULT_ICON_SIZE = 48
 
-# Icon size constants
 SMALL_ICON_SIZE = 16
 STANDARD_ICON_SIZE = 48
 LARGE_ICON_SIZE = 96
@@ -118,7 +116,6 @@ class _SVGLoader:
                 logging.error("Failed to load icon file %s: %s", file_name, e)
                 return None
 
-        # Replace entities
         for entity, value in entities.items():
             if isinstance(value, str):
                 xml = f'<!ENTITY {entity} "{value}">'
@@ -206,7 +203,6 @@ class _IconBuffer:
         if self.stroke_color:
             entities["stroke_color"] = self.stroke_color
 
-        # Handle Color objects
         processed_entities = {}
         for k, v in entities.items():
             if hasattr(v, 'get_svg'):
@@ -225,7 +221,6 @@ class _IconBuffer:
         if not file_name:
             return attach_x, attach_y
 
-        # Try to read from .icon file
         icon_config_file = file_name.replace(".svg", ".icon")
         if icon_config_file != file_name and os.path.exists(icon_config_file):
             try:
@@ -252,7 +247,6 @@ class _IconBuffer:
         elif icon_name:
             icon_theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default())
 
-            # Use IconTheme.lookup_icon for themed icon resolution
             icon_paintable = icon_theme.lookup_icon(
                 icon_name,
                 None,
@@ -327,7 +321,6 @@ class _IconBuffer:
         if badge_file_name.endswith(".svg"):
             handle = self._load_svg(badge_file_name)
             if handle:
-                # Get SVG dimensions
                 svg_rect = handle.get_intrinsic_size_in_pixels()
                 if svg_rect[0]:  # has_width
                     icon_width, icon_height = svg_rect[1], svg_rect[2]
@@ -336,7 +329,6 @@ class _IconBuffer:
 
                 context.scale(float(size) / icon_width, float(size) / icon_height)
 
-                # Create viewport
                 viewport = Rsvg.Rectangle()
                 viewport.x = 0
                 viewport.y = 0
@@ -387,14 +379,13 @@ class _IconBuffer:
         if cache_key in self._surface_cache:
             return self._surface_cache[cache_key]
 
-        # Handle pixbuf directly
         if self.pixbuf:
             surface = self._create_surface_from_pixbuf(self.pixbuf, sensitive)
             if surface:
                 self._surface_cache[cache_key] = surface
             return surface
 
-        # Try to load from file or theme, fallback to document-generic
+        # fall back to document-generic if neither file nor theme icon resolves
         for file_name, icon_name in [
             (self.file_name, self.icon_name),
             (None, "document-generic"),
@@ -440,7 +431,6 @@ class _IconBuffer:
             )
             ctx.paint()
 
-        # Scale pixbuf to fit
         pb_width, pb_height = pixbuf.get_width(), pixbuf.get_height()
         scale_x = width / pb_width
         scale_y = height / pb_height
@@ -491,20 +481,16 @@ class _IconBuffer:
         if not handle:
             return None
 
-        # SVG dimensions
         svg_rect = handle.get_intrinsic_size_in_pixels()
         if svg_rect[0]:  # has_width
             icon_width, icon_height = int(svg_rect[1]), int(svg_rect[2])
         else:
-            # Fallback dimensions
             icon_width = icon_height = 48
 
-        # badge info and padding
         badge_info = self._get_badge_info(icon_info, icon_width, icon_height)
         padding = badge_info.icon_padding
         width, height = self._get_size(icon_width, icon_height, padding)
 
-        # Create surface
         if self.background_color is None:
             surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, int(width), int(height))
         else:
@@ -521,24 +507,20 @@ class _IconBuffer:
             )
             ctx.paint()
 
-        # Scale context for icon
         ctx.scale(
             float(width) / (icon_width + padding * 2),
             float(height) / (icon_height + padding * 2),
         )
         ctx.save()
 
-        # Translate for padding
         ctx.translate(padding, padding)
 
-        # Create viewport
         viewport = Rsvg.Rectangle()
         viewport.x = 0
         viewport.y = 0
         viewport.width = icon_width
         viewport.height = icon_height
 
-        # Render main icon
         if sensitive:
             if self.alpha == 1.0:
                 handle.render_document(ctx, viewport)
@@ -553,7 +535,6 @@ class _IconBuffer:
             ctx.pop_group_to_source()
             ctx.paint_with_alpha(0.5 * self.alpha)
 
-        # Draw badge if present
         if self.badge_name:
             ctx.restore()
             ctx.translate(badge_info.attach_x, badge_info.attach_y)
@@ -609,7 +590,6 @@ class Icon(Gtk.Widget):
             width = self.get_width()
             height = self.get_height()
 
-            # Center the icon
             x = (width - surface.get_width()) / 2
             y = (height - surface.get_height()) / 2
 
@@ -625,7 +605,6 @@ class Icon(Gtk.Widget):
             finally:
                 snapshot.restore()
 
-        # Snapshot any children (e.g., attached Popovers)
         child = self.get_first_child()
         while child:
             self.snapshot_child(child, snapshot)
@@ -654,7 +633,6 @@ class Icon(Gtk.Widget):
                 child.allocate(width, height, baseline, None)
             child = child.get_next_sibling()
 
-    # Properties
     def get_icon_name(self) -> Optional[str]:
         return self._buffer.icon_name
 
@@ -681,7 +659,6 @@ class Icon(Gtk.Widget):
             self.queue_resize()
             self.queue_draw()
 
-    # Legacy aliases for compatibility
     def get_size(self) -> int:
         return self.get_pixel_size()
 
@@ -742,7 +719,6 @@ class Icon(Gtk.Widget):
         """Get size of badge icon in pixels."""
         return int(_BADGE_SIZE * self.get_pixel_size())
 
-    # GObject properties
     icon_name = GObject.Property(
         type=str, default=None, getter=get_icon_name, setter=set_icon_name
     )
@@ -834,31 +810,24 @@ class EventIcon(Icon):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        # Set up gesture handling
         self._setup_gestures()
 
-        # Set up palette invoker (restoring GTK3 behavior)
         from sugar4.graphics.palette import CursorInvoker, Palette
         self._palette_invoker = CursorInvoker()
         self._palette_invoker.attach(self)
 
     def _setup_gestures(self):
-        """Set up gesture controllers for event handling."""
-        # Click gesture
         click_gesture = Gtk.GestureClick()
         click_gesture.connect("pressed", self._on_pressed)
         click_gesture.connect("released", self._on_released)
         self.add_controller(click_gesture)
 
     def _on_pressed(self, gesture: Gtk.GestureClick, n_press: int, x: float, y: float):
-        """Handle press events."""
         self.emit("pressed", x, y)
 
     def _on_released(self, gesture: Gtk.GestureClick, n_press: int, x: float, y: float):
-        """Handle release events."""
         self.emit("released", x, y)
-        if n_press == 1:  # Single click
-            # Check if release is within widget bounds
+        if n_press == 1:
             width = self.get_width()
             height = self.get_height()
             if 0 <= x <= width and 0 <= y <= height:
@@ -883,7 +852,6 @@ class EventIcon(Icon):
         """Set cache setting."""
         self._buffer.cache = cache
 
-    # Additional properties for EventIcon
     background_color = GObject.Property(
         type=object,
         default=None,
@@ -939,19 +907,15 @@ class CanvasIcon(EventIcon):
         self._button_down = False
         self._palette_up = False
 
-        # Set up hover and focus controllers
         self._setup_state_controllers()
 
     def _setup_state_controllers(self):
-        """Set up state change controllers."""
-        # Motion controller for hover effects
         motion_controller = Gtk.EventControllerMotion()
         motion_controller.connect("enter", self._on_enter)
         motion_controller.connect("leave", self._on_leave)
         self.add_controller(motion_controller)
 
     def _on_enter(self, controller, x, y):
-        """Handle mouse enter."""
         self.set_state_flags(Gtk.StateFlags.PRELIGHT, False)
         if self._button_down:
             self.set_state_flags(Gtk.StateFlags.ACTIVE, False)
@@ -965,13 +929,11 @@ class CanvasIcon(EventIcon):
                 Gtk.StateFlags.PRELIGHT | Gtk.StateFlags.ACTIVE)
 
     def _on_pressed(self, gesture, n_press, x, y):
-        """Handle canvas press."""
         self._button_down = True
         self.set_state_flags(Gtk.StateFlags.ACTIVE, False)
         super()._on_pressed(gesture, n_press, x, y)
 
     def _on_released(self, gesture, n_press, x, y):
-        """Handle canvas release."""
         self.unset_state_flags(Gtk.StateFlags.ACTIVE)
         self._button_down = False
         super()._on_released(gesture, n_press, x, y)
@@ -990,28 +952,18 @@ class CanvasIcon(EventIcon):
         self.unset_state_flags(Gtk.StateFlags.PRELIGHT)
 
     def do_snapshot(self, snapshot):
-        """Override to render background based on state."""
-        # Get allocation and style context
         width = self.get_width()
         height = self.get_height()
 
-        # Render background based on state
         style_context = self.get_style_context()
         style_context.save()
-
-        # Add CSS class for styling
         style_context.add_class("canvas-icon")
-
-        # Render background
         snapshot.render_background(style_context, 0, 0, width, height)
-
         style_context.restore()
 
-        # Call parent to render icon
         super().do_snapshot(snapshot)
 
 
-# Simplified cell renderer for list/tree view compatibility
 class CellRendererIcon(Gtk.CellRenderer):
     """
     Icon renderer for use in list/tree views.
@@ -1162,7 +1114,6 @@ class CellRendererIcon(Gtk.CellRenderer):
         return True
 
 
-# Utility functions
 def get_icon_file_name(icon_name: str) -> Optional[str]:
     """
     Resolve icon name to file path using icon theme.
@@ -1255,14 +1206,12 @@ def get_surface(
     return buffer.get_surface()
 
 
-# Import Graphene for snapshot-based rendering operations
 try:
     gi.require_version("Graphene", "1.0")
     from gi.repository import Graphene
 except (ImportError, ValueError):
     logging.warning("Graphene not available, icon rendering may be limited")
 
-    # Provide fallback
     class _GraphenePoint:
         def init(self, x, y):
             self.x, self.y = x, y

--- a/src/sugar4/graphics/icon.py
+++ b/src/sugar4/graphics/icon.py
@@ -27,9 +27,6 @@ are SVG files that are re-coloured with a fill and a stroke colour. Typically,
 icons representing the system use a greyscale color palette, whereas icons
 representing people take on their selected XoColors.
 
-This module provides modern icon widgets using native gesture handling
-and snapshot-based rendering for improved performance and accessibility.
-
 Classes:
     Icon: Basic icon widget for displaying themed icons
     EventIcon: Icon with mouse event handling using gesture controllers
@@ -590,6 +587,9 @@ class Icon(Gtk.Widget):
         pixel_size: int = STANDARD_ICON_SIZE,
         **kwargs,
     ):
+        if "file" in kwargs:
+            file_name = kwargs.pop("file")
+
         self._buffer = _IconBuffer()
 
         super().__init__(**kwargs)
@@ -780,22 +780,23 @@ class Icon(Gtk.Widget):
             self.queue_draw()
 
     def get_gtk_image(self) -> Gtk.Image:
-        """
-        Create a Gtk.Image from this icon for compatibility.
-
-        Returns:
-            Gtk.Image: Image widget with icon content
-        """
+        """Create a Gtk.Image from this icon."""
         surface = self._buffer.get_surface(self.get_sensitive())
         if surface:
-            # Convert surface to pixbuf then to texture
-            pixbuf = Gdk.pixbuf_get_from_surface(
-                surface, 0, 0, surface.get_width(), surface.get_height()
+            # GTK4: Gdk.pixbuf_get_from_surface() removed — extract raw bytes
+            # from the Cairo ImageSurface and wrap with Gdk.MemoryTexture.
+            w = surface.get_width()
+            h = surface.get_height()
+            stride = surface.get_stride()
+            data = bytes(surface.get_data())
+            gbytes = GLib.Bytes.new(data)
+            texture = Gdk.MemoryTexture.new(
+                w, h,
+                Gdk.MemoryFormat.B8G8R8A8_PREMULTIPLIED,
+                gbytes,
+                stride,
             )
-            if pixbuf:
-                texture = Gdk.Texture.new_for_pixbuf(pixbuf)
-                image = Gtk.Image.new_from_paintable(texture)
-                return image
+            return Gtk.Image.new_from_paintable(texture)
 
         return Gtk.Image.new_from_icon_name("image-missing")
 
@@ -981,14 +982,7 @@ class CanvasIcon(EventIcon):
 
 
 class CellRendererIcon(Gtk.CellRenderer):
-    """
-    Icon renderer for use in list/tree views.
-
-    Modern implementations use different approaches for cell rendering.
-    This provides compatibility for legacy code that may need adaptation.
-
-    Note: Consider using modern list/tree widget patterns instead.
-    """
+    """Icon renderer for use in GtkTreeView columns."""
     __gtype_name__ = 'SugarCellRendererIcon'
 
     __gsignals__ = {

--- a/src/sugar4/graphics/iconentry.py
+++ b/src/sugar4/graphics/iconentry.py
@@ -64,8 +64,6 @@ class IconEntry(Gtk.Entry):
     a built-in clear button that appears when text is present.
     """
 
-    __gtype_name__ = "SugarIconEntry"
-
     def __init__(self):
         GObject.GObject.__init__(self)
 

--- a/src/sugar4/graphics/iconentry.py
+++ b/src/sugar4/graphics/iconentry.py
@@ -73,7 +73,7 @@ class IconEntry(Gtk.Entry):
         self._clear_button_added = False
         self._loader = _SVGLoader()
 
-        key_controller = Gtk.EventControllerKey()
+        key_controller = Gtk.EventControllerKey.new()
         key_controller.connect("key-pressed", self._keypress_event_cb)
         self.add_controller(key_controller)
 

--- a/src/sugar4/graphics/iconentry.py
+++ b/src/sugar4/graphics/iconentry.py
@@ -151,14 +151,17 @@ class IconEntry(Gtk.Entry):
             viewport.height = float(height)
             handle.render_document(context, viewport)
 
-            pixbuf = Gdk.pixbuf_get_from_surface(surface, 0, 0, int(width), int(height))
-            if pixbuf is None:
-                logging.warning(
-                    "IconEntry set_icon_from_name: failed to render SVG icon '%s'.",
-                    name,
-                )
-                return
-            self.set_icon(position, pixbuf)
+            # GTK4: Gdk.pixbuf_get_from_surface() removed — build texture from
+            # raw Cairo ImageSurface bytes using Gdk.MemoryTexture.
+            data = bytes(surface.get_data())
+            gbytes = GLib.Bytes.new(data)
+            texture = Gdk.MemoryTexture.new(
+                int(width), int(height),
+                Gdk.MemoryFormat.B8G8R8A8_PREMULTIPLIED,
+                gbytes,
+                surface.get_stride(),
+            )
+            self.set_icon_from_paintable(position, texture)
         else:
             try:
                 pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(

--- a/src/sugar4/graphics/menuitem.py
+++ b/src/sugar4/graphics/menuitem.py
@@ -90,9 +90,7 @@ class MenuItem(Gtk.Button):
             self._label = Gtk.Label(label=text_label)
             self._label.set_halign(Gtk.Align.START)
             self._label.set_hexpand(True)
-            # Force label text to black
-            self._label.add_css_class("force-black")
-            style.apply_css_to_widget(self._label, ".force-black { color: #000000; }")
+            self._label.set_hexpand(True)
 
             if text_maxlen > 0:
                 self._label.set_ellipsize(style.ELLIPSIZE_MODE_DEFAULT)
@@ -106,11 +104,31 @@ class MenuItem(Gtk.Button):
 
         # Style the button to look like a menu item
         self.add_css_class("menuitem")
+        self.add_css_class("flat")
         self._apply_menu_item_styling()
 
         # Connect signals for accelerator handling
         self.connect("map", self._on_mapped)
         self.connect("unmap", self._on_unmapped)
+
+    def set_image(self, icon):
+        """
+        Set the icon of the menu item.
+        """
+        content_box = self.get_child()
+        if not content_box:
+            return
+            
+        # Remove existing icon if there is one
+        child = content_box.get_first_child()
+        while child:
+            if isinstance(child, Icon):
+                content_box.remove(child)
+                break
+            child = child.get_next_sibling()
+            
+        if icon:
+            content_box.prepend(icon)
 
     def _apply_menu_item_styling(self):
         """Apply CSS styling to make button look like a menu item."""
@@ -122,10 +140,10 @@ class MenuItem(Gtk.Button):
             padding: 4px 6px;
         }
         button.menuitem:hover {
-            background: alpha(@theme_selected_bg_color, 0.1);
+            background: alpha(currentColor, 0.1);
         }
         button.menuitem:active {
-            background: alpha(@theme_selected_bg_color, 0.2);
+            background: alpha(currentColor, 0.2);
         }
         """
         style.apply_css_to_widget(self, css)
@@ -232,6 +250,32 @@ class MenuItem(Gtk.Button):
         if self._label:
             return self._label.get_text()
         return ""
+
+    def get_submenu(self):
+        return getattr(self, '_submenu', None)
+
+    def set_submenu(self, submenu):
+        self._submenu = submenu
+        if hasattr(self, '_popover') and self._popover:
+            self._popover.unparent()
+            self._popover = None
+            
+        if submenu is not None:
+            self._popover = Gtk.PopoverMenu.new_from_model(submenu)
+            self._popover.set_parent(self)
+            self._popover.set_position(Gtk.PositionType.RIGHT)
+            
+            # Show popover when clicked
+            if not hasattr(self, '_popover_click_handler'):
+                self._popover_click_handler = self.connect('clicked', self._show_popover)
+        else:
+            if hasattr(self, '_popover_click_handler'):
+                self.disconnect(self._popover_click_handler)
+                del self._popover_click_handler
+
+    def _show_popover(self, button):
+        if hasattr(self, '_popover') and self._popover:
+            self._popover.popup()
 
     # Properties for compatibility
     accelerator = GObject.Property(

--- a/src/sugar4/graphics/menuitem.py
+++ b/src/sugar4/graphics/menuitem.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2007, Eduardo Silva <edsiper@gmail.com>
+﻿# Copyright (C) 2007, Eduardo Silva <edsiper@gmail.com>
 # Copyright (C) 2025 MostlyK
 #
 # This library is free software; you can redistribute it and/or
@@ -161,7 +161,6 @@ class MenuItem(Gtk.Button):
         if self._accelerator is None:
             return
 
-        # Get the application and add accelerator
         app = Gio.Application.get_default()
         if app is None:
             logging.debug("No application available for accelerator")

--- a/src/sugar4/graphics/objectchooser.py
+++ b/src/sugar4/graphics/objectchooser.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2007, One Laptop Per Child
+﻿# Copyright (C) 2007, One Laptop Per Child
 # Copyright (C) 2025 MostlyK
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -87,7 +87,6 @@ def get_preview_pixbuf(preview_data, width=-1, height=-1):
 
                 preview_data = base64.b64decode(preview_data)
             elif isinstance(preview_data, bytes):
-                # Check if it's base64 encoded
                 if preview_data[1:4] != b"PNG":
                     import base64
 

--- a/src/sugar4/graphics/objectchooser.py
+++ b/src/sugar4/graphics/objectchooser.py
@@ -1,4 +1,4 @@
-﻿# Copyright (C) 2007, One Laptop Per Child
+# Copyright (C) 2007, One Laptop Per Child
 # Copyright (C) 2025 MostlyK
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -20,13 +20,13 @@ STABLE.
 """
 
 import logging
-import cairo
-import io
 
 from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf
+from gi.repository import GLib
+from gi.repository import Gio
 import dbus
 
 from sugar4.datastore import datastore
@@ -81,45 +81,19 @@ def get_preview_pixbuf(preview_data, width=-1, height=-1):
 
     if len(preview_data) > 4:
         try:
-            # Handle both base64 encoded and direct PNG data
             if isinstance(preview_data, str):
                 import base64
-
                 preview_data = base64.b64decode(preview_data)
             elif isinstance(preview_data, bytes):
                 if preview_data[1:4] != b"PNG":
                     import base64
-
                     preview_data = base64.b64decode(preview_data)
 
-            # Create pixbuf from PNG data
-            png_file = io.BytesIO(preview_data)
-
-            # Load image and scale to dimensions
-            surface = cairo.ImageSurface.create_from_png(png_file)
-            png_width = surface.get_width()
-            png_height = surface.get_height()
-
-            # Calculate scaling to fit within target dimensions
-            scale_w = width / png_width
-            scale_h = height / png_height
-            scale = min(scale_w, scale_h)
-
-            # Create scaled surface
-            scaled_width = int(png_width * scale)
-            scaled_height = int(png_height * scale)
-
-            preview_surface = cairo.ImageSurface(
-                cairo.FORMAT_ARGB32, scaled_width, scaled_height
-            )
-            cr = cairo.Context(preview_surface)
-            cr.scale(scale, scale)
-            cr.set_source_surface(surface)
-            cr.paint()
-
-            # Convert to pixbuf
-            pixbuf = Gdk.pixbuf_get_from_surface(
-                preview_surface, 0, 0, scaled_width, scaled_height
+            # Load and scale via GdkPixbuf directly (no Cairo surface needed).
+            stream = GLib.Bytes.new(preview_data)
+            gstream = Gio.MemoryInputStream.new_from_bytes(stream)
+            pixbuf = GdkPixbuf.Pixbuf.new_from_stream_at_scale(
+                gstream, width, height, True, None
             )
         except Exception:
             logging.exception("Error while loading the preview")

--- a/src/sugar4/graphics/palette.py
+++ b/src/sugar4/graphics/palette.py
@@ -403,6 +403,9 @@ class Palette(PaletteWindow):
             self._setup_widget()
 
             self._palette_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+            # Guard against double-parenting: unparent first if already parented
+            if self._primary_event_box.get_parent() is not None:
+                self._primary_event_box.unparent()
             self._palette_box.append(self._primary_event_box)
             self._palette_box.append(self._secondary_box)
 
@@ -499,6 +502,11 @@ class Palette(PaletteWindow):
 
             self._widget = _PaletteMenuWidget()
 
+            # Critical: Must unparent _primary_event_box from any existing parent
+            # before re-parenting it inside _HeaderItem. Without this GTK4 aborts
+            # with "assertion failed: (priv->root == NULL)".
+            if self._primary_event_box.get_parent() is not None:
+                self._primary_event_box.unparent()
             self._label_menuitem = _HeaderItem(self._primary_event_box)
             self._widget.append(self._label_menuitem)
 

--- a/src/sugar4/graphics/palette.py
+++ b/src/sugar4/graphics/palette.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2007, Eduardo Silva <edsiper@gmail.com>
+﻿# Copyright (C) 2007, Eduardo Silva <edsiper@gmail.com>
 # Copyright (C) 2008, One Laptop Per Child
 # Copyright (C) 2009, Tomeu Vizoso
 # Copyright (C) 2011, Benjamin Berg <benjamin@sipsolutions.net>
@@ -100,7 +100,6 @@ class _HeaderItem(Gtk.Widget):
         height = self.get_height()
 
         if width > 0 and height > 0:
-            # Create a colored rectangle for the separator
             color = Gdk.RGBA()
             color.red = color.green = color.blue = 0.5  # Grey
             color.alpha = 1.0
@@ -464,7 +463,6 @@ class Palette(PaletteWindow):
         self._update_separators()
 
     def __widget_button_release_cb(self, gesture, n_press, x, y):
-        # Check if the event widget is a PaletteMenuItem
         widget = gesture.get_widget()
         while widget:
             if isinstance(widget, PaletteMenuItem):
@@ -480,7 +478,6 @@ class Palette(PaletteWindow):
         return self._label.measure(Gtk.Orientation.HORIZONTAL, -1)[1]
 
     def _update_separators(self):
-        # Check if there are content children
         if self._content is not None:
             visible = self._content.get_first_child() is not None
             self._separator.set_visible(visible)
@@ -555,7 +552,6 @@ class PaletteActionBar(Gtk.Box):
 
         if icon_name:
             icon = Icon(icon_name=icon_name, pixel_size=style.SMALL_ICON_SIZE)
-            # GTK4: Use set_child instead of set_image
             box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4)
             box.append(icon)
             box.append(Gtk.Label(label=label))

--- a/src/sugar4/graphics/palette.py
+++ b/src/sugar4/graphics/palette.py
@@ -94,26 +94,19 @@ class _HeaderItem(Gtk.Widget):
             self._child_widget.allocate(width, height, baseline, None)
 
     def do_snapshot(self, snapshot):
-        """Snapshot implementation for custom drawing."""
-        # Draw separator line at bottom
         width = self.get_width()
         height = self.get_height()
 
         if width > 0 and height > 0:
             color = Gdk.RGBA()
-            color.red = color.green = color.blue = 0.5  # Grey
+            color.red = color.green = color.blue = 0.5
             color.alpha = 1.0
 
             line_height = 2
-            rect = Gdk.Rectangle()
-            rect.x = 0
-            rect.y = height - line_height
-            rect.width = width
-            rect.height = line_height
-
-        snapshot.append_color(
-            color, Graphene.Rect().init(rect.x, rect.y, rect.width, rect.height)
-        )
+            snapshot.append_color(
+                color,
+                Graphene.Rect().init(0, height - line_height, width, line_height),
+            )
 
         if self._child_widget:
             self.snapshot_child(self._child_widget, snapshot)
@@ -122,8 +115,6 @@ class _HeaderItem(Gtk.Widget):
         if self._child_widget:
             self._child_widget.unparent()
             self._child_widget = None
-
-    # TODO: Dispose here
 
 
 class Palette(PaletteWindow):

--- a/src/sugar4/graphics/palette.py
+++ b/src/sugar4/graphics/palette.py
@@ -182,15 +182,26 @@ class Palette(PaletteWindow):
         labels_box.set_hexpand(True)
         self._primary_event_box.append(labels_box)
 
-        # Primary label
+        # Primary label row
+        self._primary_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        self._primary_row.set_spacing(style.DEFAULT_SPACING * 2)
+
         self._label = Gtk.Label()
         self._label.set_halign(Gtk.Align.START)
         self._label.set_valign(Gtk.Align.CENTER)
+        self._label.set_hexpand(True)
+        self._primary_row.append(self._label)
+
+        self._accel_label = Gtk.Label()
+        self._accel_label.set_halign(Gtk.Align.END)
+        self._accel_label.set_valign(Gtk.Align.CENTER)
+        self._accel_label.set_visible(False)
+        self._primary_row.append(self._accel_label)
 
         if text_maxlen > 0:
             self._label.set_max_width_chars(text_maxlen)
             self._label.set_ellipsize(style.ELLIPSIZE_MODE_DEFAULT)
-        labels_box.append(self._label)
+        labels_box.append(self._primary_row)
 
         # Secondary label
         self._secondary_label = Gtk.Label()
@@ -276,23 +287,35 @@ class Palette(PaletteWindow):
         self._secondary_box.append(self._content)
 
     def _update_accel_widget(self):
-        if (
+        accel_text = getattr(self, '_accel_path', None)
+
+        if accel_text is None and (
             self.props.invoker is not None
             and hasattr(self.props.invoker, "props")
             and hasattr(self.props.invoker.props, "widget")
         ):
-            # GTK4: Set accelerator widget if the label supports it
-            if hasattr(self._label, "set_accel_widget"):
-                self._label.set_accel_widget(self.props.invoker.props.widget)
+            widget = self.props.invoker.props.widget
+            
+            if hasattr(widget, "props") and hasattr(widget.props, "accelerator"):
+                accel_text = widget.props.accelerator
+                
+        if accel_text:
+            self._accel_label.set_text(accel_text)
+            self._accel_label.set_visible(True)
+        else:
+            self._accel_label.set_visible(False)
 
     def set_primary_text(self, label, accel_path=None):
         self._primary_text = label
+        self._accel_path = accel_path
         if label is not None:
             label = GLib.markup_escape_text(label)
             self._label.set_markup(f"<b>{label}</b>")
             self._label.set_visible(True)
         else:
             self._label.set_visible(False)
+            
+        self._update_accel_widget()
 
     def get_primary_text(self):
         return self._primary_text
@@ -451,12 +474,10 @@ class Palette(PaletteWindow):
         return False
 
     def get_label_width(self):
-        # GTK4: Get preferred width
-        min_width, nat_width = self._label.get_preferred_size()
-        accel_width = 0
-        if hasattr(self._label, "get_accel_width"):
-            accel_width = self._label.get_accel_width()
-        return nat_width.width + accel_width
+        # GTK4 measure API returns (minimum, natural)
+        if hasattr(self, "_primary_row"):
+            return self._primary_row.measure(Gtk.Orientation.HORIZONTAL, -1)[1]
+        return self._label.measure(Gtk.Orientation.HORIZONTAL, -1)[1]
 
     def _update_separators(self):
         # Check if there are content children

--- a/src/sugar4/graphics/palette.py
+++ b/src/sugar4/graphics/palette.py
@@ -226,12 +226,7 @@ class Palette(PaletteWindow):
 
     def _setup_widget(self):
         super()._setup_widget()
-        if hasattr(self._widget, "connect"):
-            self._widget.connect("unrealize", self.__destroy_cb)
-
-    def __destroy_cb(self, widget):
-        self.popdown(immediate=True)
-        self._widget = None
+        # "unrealize" logic was removed, destruction is handled by destroy() in PaletteWindow
 
     def __notify_invoker_cb(self, palette, pspec):
         invoker = self.props.invoker
@@ -503,10 +498,11 @@ class Palette(PaletteWindow):
                         child = next_child
 
                 self._teardown_widget()
-                if hasattr(self._widget, "destroy"):
-                    self._widget.destroy()
-                elif hasattr(self._widget, "unparent"):
+                if hasattr(self._widget, "popdown"):
+                    self._widget.popdown()
+                if self._widget.get_parent() is not None:
                     self._widget.unparent()
+                self._widget = None
 
             self._widget = _PaletteMenuWidget()
 

--- a/src/sugar4/graphics/palette.py
+++ b/src/sugar4/graphics/palette.py
@@ -225,7 +225,8 @@ class Palette(PaletteWindow):
 
     def _setup_widget(self):
         super()._setup_widget()
-        self._widget.connect("destroy", self.__destroy_cb)
+        if hasattr(self._widget, "connect") and GObject.signal_lookup("destroy", self._widget):
+            self._widget.connect("destroy", self.__destroy_cb)
 
     def __destroy_cb(self, palette):
         self.popdown(immediate=True)
@@ -491,7 +492,10 @@ class Palette(PaletteWindow):
                         child = next_child
 
                 self._teardown_widget()
-                self._widget.destroy()
+                if hasattr(self._widget, "destroy"):
+                    self._widget.destroy()
+                elif hasattr(self._widget, "unparent"):
+                    self._widget.unparent()
 
             self._widget = _PaletteMenuWidget()
 

--- a/src/sugar4/graphics/palette.py
+++ b/src/sugar4/graphics/palette.py
@@ -1,4 +1,4 @@
-﻿# Copyright (C) 2007, Eduardo Silva <edsiper@gmail.com>
+# Copyright (C) 2007, Eduardo Silva <edsiper@gmail.com>
 # Copyright (C) 2008, One Laptop Per Child
 # Copyright (C) 2009, Tomeu Vizoso
 # Copyright (C) 2011, Benjamin Berg <benjamin@sipsolutions.net>
@@ -235,12 +235,11 @@ class Palette(PaletteWindow):
 
     def _setup_widget(self):
         super()._setup_widget()
-        if hasattr(self._widget, "connect") and GObject.signal_lookup("destroy", self._widget):
-            self._widget.connect("destroy", self.__destroy_cb)
+        if hasattr(self._widget, "connect"):
+            self._widget.connect("unrealize", self.__destroy_cb)
 
-    def __destroy_cb(self, palette):
+    def __destroy_cb(self, widget):
         self.popdown(immediate=True)
-        # Break the reference cycle to help with garbage collection
         self._widget = None
 
     def __notify_invoker_cb(self, palette, pspec):

--- a/src/sugar4/graphics/palettemenu.py
+++ b/src/sugar4/graphics/palettemenu.py
@@ -166,6 +166,8 @@ class PaletteMenuBox(Gtk.Box):
         hbox.set_margin_end(horizontal_padding)
         hbox.append(widget)
 
+        widget.bind_property("visible", vbox, "visible", GObject.BindingFlags.SYNC_CREATE)
+
         return vbox
 
 
@@ -298,6 +300,12 @@ class PaletteMenuItem(Gtk.Button):
         """Handle button activation - emits our custom signal."""
         # this has been done to remove the conflict with Gtk.Button's activate
         self.emit("item-activated")
+        parent = self.get_parent()
+        while parent:
+            if isinstance(parent, Gtk.Popover):
+                parent.popdown()
+                break
+            parent = parent.get_parent()
 
     def _apply_menu_item_styling(self):
         """Styling is handled by sugar.css via .palette-menu-item class rules."""
@@ -319,6 +327,12 @@ class PaletteMenuItem(Gtk.Button):
     def _clicked_cb(self, button):
         """Handle button click and emit activate signal."""
         self.emit("item-activated")
+        parent = self.get_parent()
+        while parent:
+            if isinstance(parent, Gtk.Popover):
+                parent.popdown()
+                break
+            parent = parent.get_parent()
 
     def _on_enter_notify(self, controller, x, y):
         """Handle mouse enter event."""

--- a/src/sugar4/graphics/palettemenu.py
+++ b/src/sugar4/graphics/palettemenu.py
@@ -296,8 +296,8 @@ class PaletteMenuItem(Gtk.Button):
         # gesture controllers for hover effects
         self._setup_gestures()
 
-        # Connect to activate signal
-        self.connect("activate", self._clicked_cb)
+        # Connect to clicked signal so that clicks emit 'activate' for compatibility
+        self.connect("clicked", self._clicked_cb)
 
     def _on_activate(self, button):
         """Handle button activation - emits our custom signal."""

--- a/src/sugar4/graphics/palettemenu.py
+++ b/src/sugar4/graphics/palettemenu.py
@@ -109,6 +109,7 @@ class PaletteMenuBox(Gtk.Box):
     def __init__(self):
         super().__init__(orientation=Gtk.Orientation.VERTICAL)
         self.set_spacing(2)  # Small default spacing
+        self.add_css_class('palette-content-box')
 
     def append_item(
         self, item_or_widget, horizontal_padding=None, vertical_padding=None
@@ -179,25 +180,15 @@ class PaletteMenuItemSeparator(Gtk.Separator):
     def __init__(self):
         super().__init__(orientation=Gtk.Orientation.HORIZONTAL)
 
-        # Set minimum height for the separator
-        self.set_size_request(-1, style.DEFAULT_SPACING * 2)
+        # Set minimum height for the separator via CSS only
+
 
         self.add_css_class("palette-menu-separator")
         self._apply_separator_styling()
 
     def _apply_separator_styling(self):
-        """Apply CSS styling for the separator."""
-        css = """
-        separator.palette-menu-separator {
-            margin: 2px 6px;
-            min-height: 1px;
-            background: alpha(@theme_fg_color, 0.2);
-        }
-        """
-        try:
-            style.apply_css_to_widget(self, css)
-        except Exception as e:
-            logging.warning(f"Could not apply separator CSS: {e}")
+        """Styling is handled by sugar.css via .palette-menu-separator class rules."""
+        pass
 
 
 class PaletteMenuItem(Gtk.Button):
@@ -249,10 +240,6 @@ class PaletteMenuItem(Gtk.Button):
 
         # main horizontal box
         self._hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-        self._hbox.set_margin_start(style.DEFAULT_PADDING)
-        self._hbox.set_margin_end(style.DEFAULT_PADDING)
-        self._hbox.set_margin_top(style.DEFAULT_PADDING // 2)
-        self._hbox.set_margin_bottom(style.DEFAULT_PADDING // 2)
 
         # icon if specified
         if icon_name is not None:
@@ -270,12 +257,6 @@ class PaletteMenuItem(Gtk.Button):
             self.label = Gtk.Label(label=text_label)
             self.label.set_halign(Gtk.Align.START)
             self.label.set_hexpand(True)
-            # Force black text
-            # TODO: Can also not do this based on feedback
-            self.label.add_css_class("force-black")
-            from sugar4.graphics import style as _style
-
-            _style.apply_css_to_widget(self.label, ".force-black { color: #000000; }")
 
             if text_maxlen > 0:
                 self.label.set_max_width_chars(text_maxlen)
@@ -291,13 +272,27 @@ class PaletteMenuItem(Gtk.Button):
         self.set_child(self._hbox)
 
         self.add_css_class("palette-menu-item")
+        self.add_css_class("flat")
         self._apply_menu_item_styling()
 
         # gesture controllers for hover effects
         self._setup_gestures()
 
         # Connect to clicked signal so that clicks emit 'activate' for compatibility
-        self.connect("clicked", self._clicked_cb)
+        super().connect("clicked", self._clicked_cb)
+
+    def connect(self, detailed_signal, handler, *args, **kwargs):
+        """Map legacy 'activate' signal to 'item-activated'."""
+        if detailed_signal == "activate":
+            detailed_signal = "item-activated"
+        return super().connect(detailed_signal, handler, *args, **kwargs)
+
+    def set_icon_widget(self, icon):
+        if self.icon is not None:
+            self._hbox.remove(self.icon)
+        self.icon = icon
+        if icon is not None:
+            self._hbox.prepend(icon)
 
     def _on_activate(self, button):
         """Handle button activation - emits our custom signal."""
@@ -305,28 +300,13 @@ class PaletteMenuItem(Gtk.Button):
         self.emit("item-activated")
 
     def _apply_menu_item_styling(self):
-        """Apply CSS styling to make button look like a menu item."""
-        css = """
-        button.palette-menu-item {
-            background: transparent;
-            border: none;
-            border-radius: 4px;
-            padding: 0;
-        }
-        button.palette-menu-item:hover {
-            background: alpha(@theme_selected_bg_color, 0.1);
-        }
-        button.palette-menu-item:active {
-            background: alpha(@theme_selected_bg_color, 0.2);
-        }
-        button.palette-menu-item:disabled {
-            opacity: 0.5;
-        }
-        """
-        try:
-            style.apply_css_to_widget(self, css)
-        except Exception as e:
-            logging.warning(f"Could not apply menu item CSS: {e}")
+        """Styling is handled by sugar.css via .palette-menu-item class rules."""
+        # The sugar.css file applies all palette-menu-item styling including:
+        # - background-color: transparent (normal)
+        # - background-color: @sugar_button_grey (hover)
+        # - color: @sugar_white (always white text)
+        # - padding: 8px 11px, border: none, min-height: 30px
+        pass
 
     def _setup_gestures(self):
         """Set up gesture controllers for hover effects."""
@@ -338,16 +318,16 @@ class PaletteMenuItem(Gtk.Button):
 
     def _clicked_cb(self, button):
         """Handle button click and emit activate signal."""
-        self.emit("activate")
+        self.emit("item-activated")
 
     def _on_enter_notify(self, controller, x, y):
         """Handle mouse enter event."""
-        # TODO: Add Hover Effect
+        # CSS hover state handles the background color change automatically
         pass
 
     def _on_leave_notify(self, controller):
         """Handle mouse leave event."""
-        # TODO: Add hover Effect
+        # CSS hover state handles the background color change automatically
         pass
 
     def set_label(self, text_label):
@@ -360,6 +340,11 @@ class PaletteMenuItem(Gtk.Button):
         """
         if self.label:
             self.label.set_text(text_label)
+        else:
+            self.label = Gtk.Label(label=text_label)
+            self.label.set_halign(Gtk.Align.START)
+            self.label.set_hexpand(True)
+            self._hbox.append(self.label)
 
     def get_label(self):
         """
@@ -402,13 +387,6 @@ class PaletteMenuItem(Gtk.Button):
             self._accelerator_label = Gtk.Label(label=text)
             self._accelerator_label.set_halign(Gtk.Align.END)
             self._accelerator_label.add_css_class("dim-label")
-            # Force black text for accelerator label
-            self._accelerator_label.add_css_class("force-black")
-            from sugar4.graphics import style as _style
-
-            _style.apply_css_to_widget(
-                self._accelerator_label, ".force-black { color: #000000; }"
-            )
             self._hbox.append(self._accelerator_label)
 
     def set_sensitive(self, sensitive):

--- a/src/sugar4/graphics/palettewindow.py
+++ b/src/sugar4/graphics/palettewindow.py
@@ -655,11 +655,12 @@ class PaletteWindow(GObject.GObject):
 
     def destroy(self):
         if self._widget is not None:
-            if hasattr(self._widget, "destroy"):
-                self._widget.destroy()
-            elif hasattr(self._widget, "unparent"):
+            self._teardown_widget()
+            if hasattr(self._widget, "popdown"):
+                self._widget.popdown()
+            if self._widget.get_parent() is not None:
                 self._widget.unparent()
-            self._widget = None  # Prevent use-after-destroy (GTK_IS_WIDGET assertion)
+            self._widget = None  # Release reference for GTK4 GC
 
     def __destroy_cb(self, palette):
         """Handle widget destruction."""
@@ -1062,7 +1063,8 @@ class Invoker(GObject.GObject):
     def detach(self):
         self.parent = None
         if self._palette is not None:
-            self._palette.destroy()
+            self._palette.popdown(immediate=True)
+            self._palette.unparent()
             self._palette = None
 
     def _get_position_for_alignment(self, alignment, palette_dim):
@@ -1279,10 +1281,6 @@ class Invoker(GObject.GObject):
         if self._palette is not None:
             self._palette.popdown(immediate=True)
             self._palette.props.invoker = None
-            GLib.idle_add(
-                lambda old_palette=self._palette: old_palette.destroy(),
-                priority=GLib.PRIORITY_LOW,
-            )  # type: ignore
 
         self._palette = palette
 
@@ -1375,10 +1373,33 @@ class WidgetInvoker(Invoker):
         self._setup_controllers()
         self.attach(parent)
 
+    def _remove_controllers(self):
+        if self._widget:
+            if self._motion_controller:
+                try:
+                    self._widget.remove_controller(self._motion_controller)
+                except Exception:
+                    pass
+                self._motion_controller = None
+            if self._click_controller:
+                try:
+                    self._widget.remove_controller(self._click_controller)
+                except Exception:
+                    pass
+                self._click_controller = None
+            if self._long_press_gesture:
+                try:
+                    self._widget.remove_controller(self._long_press_gesture)
+                except Exception:
+                    pass
+                self._long_press_gesture = None
+
     def _setup_controllers(self):
         """Set up event controllers for palette interaction."""
         if not self._widget:
             return
+
+        self._remove_controllers()
 
         # Ensure widget is focusable and sensitive for event handling
         self._widget.set_can_focus(True)
@@ -1408,17 +1429,7 @@ class WidgetInvoker(Invoker):
             pass
 
     def detach(self):
-        if self._widget:
-            try:
-                if self._motion_controller:
-                    GLib.idle_add(self._widget.remove_controller, self._motion_controller)
-                if self._click_controller:
-                    GLib.idle_add(self._widget.remove_controller, self._click_controller)
-                if self._long_press_gesture:
-                    GLib.idle_add(self._widget.remove_controller, self._long_press_gesture)
-            except Exception:
-                pass
-
+        self._remove_controllers()
         super().detach()
 
     def get_rect(self):
@@ -1444,7 +1455,6 @@ class WidgetInvoker(Invoker):
         if not self.parent:
             return
 
-        allocation = self.parent.get_allocation()
         context = self.parent.get_style_context()
         context.add_class("toolitem")
         context.add_class("palette-down")
@@ -1548,7 +1558,29 @@ class CursorInvoker(Invoker):
         if parent:
             self.attach(parent)
 
+    def _remove_controllers(self):
+        if self.parent:
+            if self._motion_controller:
+                try:
+                    self.parent.remove_controller(self._motion_controller)
+                except Exception:
+                    pass
+                self._motion_controller = None
+            if self._click_controller:
+                try:
+                    self.parent.remove_controller(self._click_controller)
+                except Exception:
+                    pass
+                self._click_controller = None
+            if self._long_press_gesture:
+                try:
+                    self.parent.remove_controller(self._long_press_gesture)
+                except Exception:
+                    pass
+                self._long_press_gesture = None
+
     def attach(self, parent):
+        self.detach()
         super().attach(parent)
 
         if self.parent:
@@ -1573,17 +1605,7 @@ class CursorInvoker(Invoker):
 
     def detach(self):
         """Detach from the parent."""
-        if self.parent:
-            try:
-                if self._motion_controller:
-                    GLib.idle_add(self.parent.remove_controller, self._motion_controller)
-                if self._click_controller:
-                    GLib.idle_add(self.parent.remove_controller, self._click_controller)
-                if self._long_press_gesture:
-                    GLib.idle_add(self.parent.remove_controller, self._long_press_gesture)
-            except Exception:
-                pass
-
+        self._remove_controllers()
         super().detach()
 
     def get_rect(self):
@@ -1744,11 +1766,14 @@ class TreeViewInvoker(Invoker):
         if self._tree_view:
             try:
                 if self._motion_controller:
-                    GLib.idle_add(self._tree_view.remove_controller, self._motion_controller)
+                    self._tree_view.remove_controller(self._motion_controller)
+                    self._motion_controller = None
                 if self._click_controller:
-                    GLib.idle_add(self._tree_view.remove_controller, self._click_controller)
+                    self._tree_view.remove_controller(self._click_controller)
+                    self._click_controller = None
                 if self._long_press_gesture:
-                    GLib.idle_add(self._tree_view.remove_controller, self._long_press_gesture)
+                    self._tree_view.remove_controller(self._long_press_gesture)
+                    self._long_press_gesture = None
             except Exception:
                 pass
 
@@ -1813,7 +1838,6 @@ class TreeViewInvoker(Invoker):
 
             if self.palette is not None:
                 self.palette.popdown(immediate=True)
-                self.palette.destroy()
                 self.palette = None
 
             self.notify_mouse_enter()
@@ -1850,7 +1874,6 @@ class TreeViewInvoker(Invoker):
             # Left mouse button
             if self.palette is not None:
                 self.palette.popdown(immediate=True)
-                self.palette.destroy()
                 self.palette = None
 
             # Handle cell renderer click manually because GTK4 TreeView single-click doesn't reliably trigger do_activate

--- a/src/sugar4/graphics/palettewindow.py
+++ b/src/sugar4/graphics/palettewindow.py
@@ -108,6 +108,9 @@ class _PaletteMenuWidget(Gtk.Popover):
 
     def __init__(self):
         super().__init__()
+        
+        self.add_css_class("palette")
+        self.add_css_class("palette-popover")
 
         # container for menu items
         self._menu_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
@@ -177,8 +180,51 @@ class _PaletteMenuWidget(Gtk.Popover):
             return
 
         self._invoker = invoker or self._invoker
-        if self._invoker and hasattr(self._invoker, "_widget"):
-            self.set_parent(self._invoker._widget)
+        if self._invoker:
+            parent_widget = None
+            if hasattr(self._invoker, "get_widget"):
+                parent_widget = self._invoker.get_widget()
+            elif hasattr(self._invoker, "parent") and self._invoker.parent is not None:
+                parent_widget = self._invoker.parent
+            elif isinstance(self._invoker, Gtk.Widget):
+                parent_widget = self._invoker
+            elif hasattr(self._invoker, "_tool") and self._invoker._tool is not None:
+                parent_widget = self._invoker._tool
+            elif hasattr(self._invoker, "_widget") and self._invoker._widget is not None:
+                parent_widget = self._invoker._widget
+            elif hasattr(self._invoker, "_tree_view") and self._invoker._tree_view is not None:
+                parent_widget = self._invoker._tree_view
+
+            if parent_widget is not None:
+                if not self.get_parent():
+                    try:
+                        self.set_parent(parent_widget)
+                        if not getattr(self, '_unparent_handler_id', None):
+                            self._unparent_handler_id = parent_widget.connect('destroy', lambda w: self.unparent() if self.get_parent() == w else None)
+                    except Exception as e:
+                        logging.warning(f"set_parent failed: {e}")
+                    if not self.get_parent():
+                        # Fallback for custom widgets that don't accept children
+                        p = parent_widget.get_parent()
+                        while p is not None:
+                            try:
+                                self.set_parent(p)
+                                if not getattr(self, '_unparent_handler_id', None):
+                                    self._unparent_handler_id = p.connect('destroy', lambda w: self.unparent() if self.get_parent() == w else None)
+                            except Exception:
+                                pass
+                            if self.get_parent():
+                                break
+                            p = p.get_parent()
+
+        if not self.get_parent():
+            logging.warning("Palette popup failed: No parent widget.")
+            return
+
+        native = self.get_parent().get_native()
+        if not native or not native.get_surface():
+            logging.warning("Palette popup failed: Parent is not in a toplevel window.")
+            return
 
         self._entered = False
         self._mouse_in_palette = False
@@ -280,8 +326,8 @@ class _PaletteMenuWidget(Gtk.Popover):
                 self.emit("enter-notify")
 
 
-class _PaletteWindowWidget(Gtk.Window):
-    """Palette window widget with modern event handling."""
+class _PaletteWindowWidget(Gtk.Popover):
+    """Palette window widget with modern event handling, inheriting from Popover."""
 
     __gtype_name__ = "SugarPaletteWindowWidget"
 
@@ -294,21 +340,44 @@ class _PaletteWindowWidget(Gtk.Window):
         super().__init__()
 
         self._palette = palette
-        self.set_decorated(False)
-        self.set_resizable(False)
 
         # Apply palette styling
         self.add_css_class("palette")
+        self.add_css_class("palette-popover")
 
         self._old_alloc = None
         self._invoker = None
         self._should_accept_focus = True
+        
+        self._entered = False
+        self._mouse_in_palette = False
+        self._mouse_in_invoker = False
+        self._up = False
 
         # Set up event controllers for GTK4
         self._motion_controller = Gtk.EventControllerMotion()
         self._motion_controller.connect("enter", self._enter_notify_cb)
         self._motion_controller.connect("leave", self._leave_notify_cb)
         self.add_controller(self._motion_controller)
+
+    def get_rect(self):
+        """Get the bounding box of the palette."""
+        rect = Gdk.Rectangle()
+        rect.width = self.get_width()
+        rect.height = self.get_height()
+        try:
+            # Attempt to get coordinates relative to the parent widget
+            parent = self.get_parent()
+            if parent:
+                native = parent.get_native()
+                if native:
+                    success, transform = self.compute_transform(native)
+                    if success and transform:
+                        rect.x = int(transform.get_value(0, 3))
+                        rect.y = int(transform.get_value(1, 3))
+        except Exception:
+            pass
+        return rect
 
     def set_accept_focus(self, focus):
         """Set whether the window accepts focus."""
@@ -319,10 +388,13 @@ class _PaletteWindowWidget(Gtk.Window):
         """Get the origin position of the window."""
         # GTK4: Window position is managed by compositor
         return (0, 0)
+        
+    def move(self, x, y):
+        pass
 
     def do_measure(self, orientation, for_size):
         """Calculate size requirements for the palette window."""
-        min_size, nat_size, min_baseline, nat_baseline = Gtk.Window.do_measure(
+        min_size, nat_size, min_baseline, nat_baseline = Gtk.Popover.do_measure(
             self, orientation, for_size
         )
 
@@ -338,27 +410,6 @@ class _PaletteWindowWidget(Gtk.Window):
 
         return min_size, nat_size, min_baseline, nat_baseline
 
-    def do_size_allocate(self, width, height, baseline):
-        """Allocate size to the palette window and its children."""
-        super().do_size_allocate(width, height, baseline)
-
-        allocation = Gdk.Rectangle()
-        allocation.x = 0
-        allocation.y = 0
-        allocation.width = width
-        allocation.height = height
-
-        if (
-            self._old_alloc is None
-            or self._old_alloc.x != allocation.x
-            or self._old_alloc.y != allocation.y
-            or self._old_alloc.width != allocation.width
-            or self._old_alloc.height != allocation.height
-        ):
-            self.queue_draw()
-
-        self._old_alloc = allocation
-
     def set_invoker(self, invoker):
         self._invoker = invoker
 
@@ -373,32 +424,84 @@ class _PaletteWindowWidget(Gtk.Window):
 
     def set_content(self, widget):
         """Set the main content widget for the palette window."""
-        # Ensure _widget exists and is a Gtk.Window
-        if not hasattr(self, "_widget") or self._widget is None:
-            self._widget = Gtk.Window()
-        self._widget.set_child(widget)
+        self.set_child(widget)
 
     def _enter_notify_cb(self, controller, x, y):
         """Handle enter notify events."""
+        self._mouse_in_palette = True
         self.emit("enter-notify")
 
     def _leave_notify_cb(self, controller):
         """Handle leave notify events."""
+        self._mouse_in_palette = False
         self.emit("leave-notify")
 
     def popup(self, invoker=None):
         """Show the window."""
-        if self.get_visible():
+        if self._up:
             return
-        print("PaletteWindow.popup called")
-        self.present()
+
+        self._invoker = invoker or self._invoker
+        if self._invoker:
+            parent_widget = None
+            if hasattr(self._invoker, "get_widget"):
+                parent_widget = self._invoker.get_widget()
+            elif hasattr(self._invoker, "parent") and self._invoker.parent is not None:
+                parent_widget = self._invoker.parent
+            elif isinstance(self._invoker, Gtk.Widget):
+                parent_widget = self._invoker
+            elif hasattr(self._invoker, "_tool") and self._invoker._tool is not None:
+                parent_widget = self._invoker._tool
+            elif hasattr(self._invoker, "_widget") and self._invoker._widget is not None:
+                parent_widget = self._invoker._widget
+            elif hasattr(self._invoker, "_tree_view") and self._invoker._tree_view is not None:
+                parent_widget = self._invoker._tree_view
+
+            if parent_widget is not None:
+                if not self.get_parent():
+                    try:
+                        self.set_parent(parent_widget)
+                        if not getattr(self, '_unparent_handler_id', None):
+                            self._unparent_handler_id = parent_widget.connect('destroy', lambda w: self.unparent() if self.get_parent() == w else None)
+                    except Exception as e:
+                        logging.warning(f"set_parent failed: {e}")
+                    if not self.get_parent():
+                        # Fallback for custom widgets that don't accept children
+                        p = parent_widget.get_parent()
+                        while p is not None:
+                            try:
+                                self.set_parent(p)
+                                if not getattr(self, '_unparent_handler_id', None):
+                                    self._unparent_handler_id = p.connect('destroy', lambda w: self.unparent() if self.get_parent() == w else None)
+                            except Exception:
+                                pass
+                            if self.get_parent():
+                                break
+                            p = p.get_parent()
+
+        if not self.get_parent():
+            logging.warning("Palette popup failed: No parent widget.")
+            return
+
+        native = self.get_parent().get_native()
+        if not native or not native.get_surface():
+            logging.warning("Palette popup failed: Parent is not in a toplevel window.")
+            return
+
+        self._entered = False
+        self._mouse_in_palette = False
+        self._mouse_in_invoker = False
+
+        super().popup()
+        self._up = True
 
     def popdown(self):
         """Hide the window."""
-        if not self.get_visible():
+        if not self._up:
             return
-        print("PaletteWindow.popdown called")
-        self.set_visible(False)
+            
+        super().popdown()
+        self._up = False
 
 
 class MouseSpeedDetector(GObject.GObject):
@@ -543,7 +646,10 @@ class PaletteWindow(GObject.GObject):
 
     def destroy(self):
         if self._widget is not None:
-            self._widget.destroy()
+            if hasattr(self._widget, "destroy"):
+                self._widget.destroy()
+            elif hasattr(self._widget, "unparent"):
+                self._widget.unparent()
 
     def __destroy_cb(self, palette):
         """Handle widget destruction."""
@@ -617,6 +723,8 @@ class PaletteWindow(GObject.GObject):
         self.popup(immediate=immediate)
 
     def is_up(self):
+        if self._widget is not None and hasattr(self._widget, "get_visible"):
+            return self._widget.get_visible()
         return self._up
 
     def _set_effective_group_id(self, group_id):
@@ -1113,9 +1221,7 @@ class Invoker(GObject.GObject):
         self.emit("right-click")
 
     def notify_toggle_state(self):
-        print("ToolInvoker.notify_toggle_state called")
         self._ensure_palette_exists()
-        print("ToolInvoker emitting 'toggle-state' signal")
         self.emit("toggle-state")
 
     def _process_event(self, x, y):
@@ -1666,7 +1772,8 @@ class TreeViewInvoker(Invoker):
         if not self._tree_view:
             return
 
-        here = self._tree_view.get_path_at_pos(int(x), int(y))
+        tx, ty = self._tree_view.convert_widget_to_tree_coords(int(x), int(y))
+        here = self._tree_view.get_path_at_pos(tx, ty)
         if here is None:
             if self._path is not None:
                 self.notify_mouse_leave()
@@ -1701,7 +1808,8 @@ class TreeViewInvoker(Invoker):
 
     def __button_release_event_cb(self, gesture, n_press, x, y):
         x, y = int(x), int(y)
-        here = self._tree_view.get_path_at_pos(x, y)  # type: ignore
+        tx, ty = self._tree_view.convert_widget_to_tree_coords(x, y)
+        here = self._tree_view.get_path_at_pos(tx, ty)  # type: ignore
         if here is None:
             return False
 
@@ -1735,10 +1843,9 @@ class TreeViewInvoker(Invoker):
         return False
 
     def __long_pressed_event_cb(self, gesture, x, y):
-        if not self._tree_view:
-            return
-
-        here = self._tree_view.get_path_at_pos(x, y)
+        x, y = int(x), int(y)
+        tx, ty = self._tree_view.convert_widget_to_tree_coords(x, y)
+        here = self._tree_view.get_path_at_pos(tx, ty)  # type: ignore
         if here is None:
             return
 

--- a/src/sugar4/graphics/palettewindow.py
+++ b/src/sugar4/graphics/palettewindow.py
@@ -197,7 +197,7 @@ class _PaletteMenuWidget(Gtk.Popover):
             parent_widget = None
             if hasattr(self._invoker, "get_widget"):
                 parent_widget = self._invoker.get_widget()
-            elif hasattr(self._invoker, "parent") and self._invoker.parent is not None:
+            elif hasattr(self._invoker, "parent") and isinstance(self._invoker.parent, Gtk.Widget):
                 parent_widget = self._invoker.parent
             elif isinstance(self._invoker, Gtk.Widget):
                 parent_widget = self._invoker
@@ -216,10 +216,6 @@ class _PaletteMenuWidget(Gtk.Popover):
                 if current_parent is None:
                     try:
                         Gtk.Widget.set_parent(self, parent_widget)
-                        parent_widget.connect(
-                            'destroy',
-                            lambda w: self.unparent() if self.get_parent() else None
-                        )
                     except Exception as e:
                         logging.warning("set_parent failed on %s: %s", parent_widget, e)
 
@@ -459,6 +455,8 @@ class _PaletteWindowWidget(Gtk.Popover):
                 parent_widget = self._invoker._widget
             elif hasattr(self._invoker, "_tree_view") and self._invoker._tree_view is not None:
                 parent_widget = self._invoker._tree_view
+            elif hasattr(self._invoker, "parent") and isinstance(self._invoker.parent, Gtk.Widget):
+                parent_widget = self._invoker.parent
 
             if parent_widget is not None:
                 current_parent = self.get_parent()
@@ -604,6 +602,10 @@ class PaletteWindow(GObject.GObject):
             self._widget.connect("destroy", self.__destroy_cb)
             self._widget.connect("enter-notify", self.__enter_notify_cb)
             self._widget.connect("leave-notify", self.__leave_notify_cb)
+            self._widget.connect("map", self.__show_cb)
+            self._widget.connect("unmap", self.__hide_cb)
+            if hasattr(self._widget, "closed"):
+                self._widget.connect("closed", self.__hide_cb)
 
         # Set up key event controller for GTK4
         self._key_controller = Gtk.EventControllerKey()
@@ -627,6 +629,8 @@ class PaletteWindow(GObject.GObject):
                 self._widget.disconnect_by_func(self.__destroy_cb)
                 self._widget.disconnect_by_func(self.__enter_notify_cb)
                 self._widget.disconnect_by_func(self.__leave_notify_cb)
+                self._widget.disconnect_by_func(self.__show_cb)
+                self._widget.disconnect_by_func(self.__hide_cb)
 
             if self._widget is not None and hasattr(self, "_key_controller"):
                 GLib.idle_add(self._widget.remove_controller, self._key_controller)
@@ -1316,7 +1320,9 @@ class Invoker(GObject.GObject):
     def get_toplevel(self):
         """Get the toplevel window - implemented by subclasses."""
         if self.parent:
-            return self.parent.get_root()
+            root = self.parent.get_root()
+            if isinstance(root, Gtk.Root):
+                return root
         return None
 
 
@@ -1510,7 +1516,9 @@ class WidgetInvoker(Invoker):
 
     def get_toplevel(self):
         if self._widget:
-            return self._widget.get_root()
+            root = self._widget.get_root()
+            if isinstance(root, Gtk.Root):
+                return root
         return None
 
     def notify_popup(self):
@@ -1566,6 +1574,8 @@ class CursorInvoker(Invoker):
         super().attach(parent)
 
         if self.parent:
+            self._remove_controllers()
+
             try:
                 self._pointer_position = _get_pointer_position(self.parent)
             except Exception:
@@ -1624,6 +1634,9 @@ class CursorInvoker(Invoker):
                 pass
         self.notify_mouse_leave()
 
+    def get_widget(self):
+        return self.parent
+
     def __button_release_event_cb(self, gesture, n_press, x, y):
         if self._long_pressed_recognized:
             self._long_pressed_recognized = False
@@ -1644,7 +1657,9 @@ class CursorInvoker(Invoker):
 
     def get_toplevel(self):
         if self.parent:
-            return self.parent.get_root()
+            root = self.parent.get_root()
+            if isinstance(root, Gtk.Root):
+                return root
         return None
 
 
@@ -1794,7 +1809,9 @@ class TreeViewInvoker(Invoker):
 
     def get_toplevel(self):
         if self._tree_view:
-            return self._tree_view.get_root()
+            root = self._tree_view.get_root()
+            if isinstance(root, Gtk.Root):
+                return root
         return None
 
     def __motion_notify_event_cb(self, controller, x, y):

--- a/src/sugar4/graphics/palettewindow.py
+++ b/src/sugar4/graphics/palettewindow.py
@@ -195,30 +195,30 @@ class _PaletteMenuWidget(Gtk.Popover):
             elif hasattr(self._invoker, "_tree_view") and self._invoker._tree_view is not None:
                 parent_widget = self._invoker._tree_view
 
-            if parent_widget is not None:
-                if not self.get_parent():
+            if parent_widget is not None and not self.get_parent():
+                # Try direct parent widget first, then root as fallback.
+                # Do NOT use a loop that swallows exceptions — partial-root
+                # states cause the GTK assertion (priv->root == NULL).
+                root = parent_widget.get_root()
+                candidates = [parent_widget]
+                if root is not None and root is not parent_widget:
+                    candidates.append(root)
+                for candidate in candidates:
                     try:
-                        self.set_parent(parent_widget)
-                        if not getattr(self, '_unparent_handler_id', None):
-                            self._unparent_handler_id = parent_widget.connect('destroy', lambda w: self.unparent() if self.get_parent() == w else None)
+                        # PyGObject requires explicit Gtk.Widget call for Popover subclasses
+                        Gtk.Widget.set_parent(self, candidate)
                     except Exception as e:
-                        logging.warning(f"set_parent failed: {e}")
-                    if not self.get_parent():
-                        # Fallback for custom widgets that don't accept children
-                        p = parent_widget.get_parent()
-                        while p is not None:
-                            try:
-                                self.set_parent(p)
-                                if not getattr(self, '_unparent_handler_id', None):
-                                    self._unparent_handler_id = p.connect('destroy', lambda w: self.unparent() if self.get_parent() == w else None)
-                            except Exception:
-                                pass
-                            if self.get_parent():
-                                break
-                            p = p.get_parent()
+                        logging.warning("set_parent failed on %s: %s", candidate, e)
+                        continue
+                    if self.get_parent():
+                        candidate.connect(
+                            'destroy',
+                            lambda w: self.unparent() if self.get_parent() else None
+                        )
+                        break
 
         if not self.get_parent():
-            logging.warning("Palette popup failed: No parent widget.")
+            logging.warning("Palette popup failed: No parent widget. parent_widget was %s, invoker was %s", parent_widget if 'parent_widget' in locals() else 'Not evaluated', self._invoker)
             return
 
         native = self.get_parent().get_native()
@@ -229,6 +229,11 @@ class _PaletteMenuWidget(Gtk.Popover):
         self._entered = False
         self._mouse_in_palette = False
         self._mouse_in_invoker = False
+
+        if self._invoker and hasattr(self._invoker, "get_rect"):
+            rect = self._invoker.get_rect()
+            if rect and hasattr(self, "set_pointing_to"):
+                self.set_pointing_to(rect)
 
         super().popup()
         self._up = True
@@ -457,27 +462,27 @@ class _PaletteWindowWidget(Gtk.Popover):
             elif hasattr(self._invoker, "_tree_view") and self._invoker._tree_view is not None:
                 parent_widget = self._invoker._tree_view
 
-            if parent_widget is not None:
-                if not self.get_parent():
+            if parent_widget is not None and not self.get_parent():
+                # Try direct parent widget first, then root as fallback.
+                # Do NOT use a loop that swallows exceptions — partial-root
+                # states cause the GTK assertion (priv->root == NULL).
+                root = parent_widget.get_root()
+                candidates = [parent_widget]
+                if root is not None and root is not parent_widget:
+                    candidates.append(root)
+                for candidate in candidates:
                     try:
-                        self.set_parent(parent_widget)
-                        if not getattr(self, '_unparent_handler_id', None):
-                            self._unparent_handler_id = parent_widget.connect('destroy', lambda w: self.unparent() if self.get_parent() == w else None)
+                        # PyGObject requires explicit Gtk.Widget call for Popover subclasses
+                        Gtk.Widget.set_parent(self, candidate)
                     except Exception as e:
-                        logging.warning(f"set_parent failed: {e}")
-                    if not self.get_parent():
-                        # Fallback for custom widgets that don't accept children
-                        p = parent_widget.get_parent()
-                        while p is not None:
-                            try:
-                                self.set_parent(p)
-                                if not getattr(self, '_unparent_handler_id', None):
-                                    self._unparent_handler_id = p.connect('destroy', lambda w: self.unparent() if self.get_parent() == w else None)
-                            except Exception:
-                                pass
-                            if self.get_parent():
-                                break
-                            p = p.get_parent()
+                        logging.warning("set_parent failed on %s: %s", candidate, e)
+                        continue
+                    if self.get_parent():
+                        candidate.connect(
+                            'destroy',
+                            lambda w: self.unparent() if self.get_parent() else None
+                        )
+                        break
 
         if not self.get_parent():
             logging.warning("Palette popup failed: No parent widget.")
@@ -491,6 +496,11 @@ class _PaletteWindowWidget(Gtk.Popover):
         self._entered = False
         self._mouse_in_palette = False
         self._mouse_in_invoker = False
+
+        if self._invoker and hasattr(self._invoker, "get_rect"):
+            rect = self._invoker.get_rect()
+            if rect and hasattr(self, "set_pointing_to"):
+                self.set_pointing_to(rect)
 
         super().popup()
         self._up = True
@@ -650,6 +660,7 @@ class PaletteWindow(GObject.GObject):
                 self._widget.destroy()
             elif hasattr(self._widget, "unparent"):
                 self._widget.unparent()
+            self._widget = None  # Prevent use-after-destroy (GTK_IS_WIDGET assertion)
 
     def __destroy_cb(self, palette):
         """Handle widget destruction."""
@@ -810,7 +821,6 @@ class PaletteWindow(GObject.GObject):
 
     def popup(self, immediate=False):
         """Show the palette."""
-        print(f"PaletteWindow.popup called with immediate={immediate}")
         if self._widget is None:
             return
 
@@ -846,8 +856,6 @@ class PaletteWindow(GObject.GObject):
 
     def popdown(self, immediate=False):
         """Hide the palette."""
-        print(f"PaletteWindow.popdown called with immediate={immediate}")
-        print(f"PaletteWindow.popdown: is_up={self._up}, widget={self._widget}")
         self._popup_anim.stop()
         self._mouse_detector.stop()
 
@@ -857,10 +865,8 @@ class PaletteWindow(GObject.GObject):
             self._popdown_anim.stop()
             if self._widget is not None:
                 if hasattr(self._widget, "popdown"):
-                    print("PaletteWindow.popdown: calling widget.popdown()")
                     self._widget.popdown()
                 else:
-                    print("PaletteWindow.popdown: setting widget invisible")
                     self._widget.set_visible(False)
 
     def on_invoker_enter(self):
@@ -889,16 +895,9 @@ class PaletteWindow(GObject.GObject):
         self.popup(immediate=True)
 
     def _invoker_toggle_state_cb(self, invoker):
-        print(f"PaletteWindow._invoker_toggle_state_cb called with invoker={invoker}")
         if self.is_up():
-            print(
-                "PaletteWindow._invoker_toggle_state_cb: palette is up, calling popdown"
-            )
             self.popdown(immediate=True)
         else:
-            print(
-                "PaletteWindow._invoker_toggle_state_cb: palette is down, calling popup"
-            )
             self.popup(immediate=True)
 
     def __enter_notify_cb(self, widget):
@@ -1340,9 +1339,6 @@ class WidgetInvoker(Invoker):
         # Ensure widget is focusable and sensitive for event handling
         self._widget.set_can_focus(True)
         self._widget.set_sensitive(True)
-        print(
-            f"WidgetInvoker._setup_controllers: set_can_focus and set_sensitive for {self._widget}"
-        )
 
         # Motion controller for enter/leave events
         self._motion_controller = Gtk.EventControllerMotion()
@@ -1363,9 +1359,6 @@ class WidgetInvoker(Invoker):
         # Connect to clicked signal if available
         try:
             if GObject.signal_lookup("clicked", self._widget):
-                print(
-                    f"WidgetInvoker._setup_controllers: connecting to 'clicked' signal for {self._widget}"
-                )
                 self._widget.connect("clicked", self.__click_event_cb)
         except (TypeError, AttributeError):
             pass
@@ -1388,24 +1381,15 @@ class WidgetInvoker(Invoker):
         if not self._widget:
             return Gdk.Rectangle()
 
+        # In GTK4, Popovers are positioned relative to their parent widget.
+        # Since we attach the Popover to self._widget, pointing_to must be
+        # in local widget coordinates.
         width = self._widget.get_width()
         height = self._widget.get_height()
 
-        # Get widget position - GTK4
-        x = y = 0
-        try:
-            native = self._widget.get_native()
-            if native:
-                success, transform = self._widget.compute_transform(native)
-                if success and transform:
-                    x = transform.get_value(0, 3)
-                    y = transform.get_value(1, 3)
-        except Exception:
-            x = y = 0
-
         rect = Gdk.Rectangle()
-        rect.x = int(x)
-        rect.y = int(y)
+        rect.x = 0
+        rect.y = 0
         rect.width = width
         rect.height = height
         return rect
@@ -1440,24 +1424,16 @@ class WidgetInvoker(Invoker):
     def __button_release_event_cb(self, gesture, n_press, x, y):
         button = gesture.get_current_button()
 
-        print(
-            f"ToolInvoker.__button_release_event_cb called: button={button}, n_press={n_press}, x={x}, y={y}"
-        )
         if button == 3:  # Right click
-            print("ToolInvoker: right click detected")
             self.notify_right_click(x, y)
             return True
         elif button == 1:  # Left click
-            print("ToolInvoker: left click detected")
             if self._lock_palette and not self.locked:
                 self.locked = True
                 if hasattr(self.parent, "set_expanded"):
                     self.parent.set_expanded(True)  # type: ignore
 
             if self._toggle_palette:
-                print(
-                    "ToolInvoker: toggle_palette is True, calling notify_toggle_state"
-                )
                 self.notify_toggle_state()
                 return True
         return False
@@ -1467,7 +1443,6 @@ class WidgetInvoker(Invoker):
         self.notify_right_click(x, y)
 
     def __click_event_cb(self, widget):
-        print(f"WidgetInvoker.__click_event_cb: 'clicked' signal received for {widget}")
         if not self._long_pressed_recognized:
             if self._lock_palette and not self.locked:
                 self.locked = True
@@ -1475,9 +1450,6 @@ class WidgetInvoker(Invoker):
                     self.parent.set_expanded(True)  # type: ignore
 
             if self._toggle_palette:
-                print(
-                    "WidgetInvoker.__click_event_cb: toggle_palette is True, calling notify_toggle_state"
-                )
                 self.notify_toggle_state()
         self._long_pressed_recognized = False
 
@@ -1738,22 +1710,9 @@ class TreeViewInvoker(Invoker):
                 cell_area.x, cell_area.y
             )
 
-            # Get widget position in root coordinates
-            root_x = root_y = 0
-            try:
-                native = self._tree_view.get_native()
-                if native:
-                    success, transform = self._tree_view.compute_transform(native)
-                    if success and transform:
-                        root_x = transform.get_value(0, 3) + widget_x
-                        root_y = transform.get_value(1, 3) + widget_y
-            except Exception:
-                root_x = widget_x
-                root_y = widget_y
-
             rect = Gdk.Rectangle()
-            rect.x = int(root_x)
-            rect.y = int(root_y)
+            rect.x = int(widget_x)
+            rect.y = int(widget_y)
             rect.width = cell_area.width
             rect.height = cell_area.height
             return rect
@@ -1762,6 +1721,9 @@ class TreeViewInvoker(Invoker):
             rect.x = rect.y = 0
             rect.width = rect.height = 50
             return rect
+
+    def get_widget(self):
+        return self._tree_view
 
     def get_toplevel(self):
         if self._tree_view:

--- a/src/sugar4/graphics/palettewindow.py
+++ b/src/sugar4/graphics/palettewindow.py
@@ -341,7 +341,6 @@ class _PaletteMenuWidget(Gtk.Popover):
 
 
 class _PaletteWindowWidget(Gtk.Popover):
-    """Palette window widget with modern event handling, inheriting from Popover."""
 
     __gtype_name__ = "SugarPaletteWindowWidget"
 
@@ -385,7 +384,6 @@ class _PaletteWindowWidget(Gtk.Popover):
         rect.width = self.get_width()
         rect.height = self.get_height()
         try:
-            # Attempt to get coordinates relative to the parent widget
             parent = self.get_parent()
             if parent:
                 native = parent.get_native()
@@ -404,9 +402,8 @@ class _PaletteWindowWidget(Gtk.Popover):
         self.set_can_focus(focus)
 
     def get_origin(self):
-        """Get the origin position of the window."""
         return (0, 0)
-        
+
     def move(self, x, y):
         pass
 
@@ -432,9 +429,8 @@ class _PaletteWindowWidget(Gtk.Popover):
         self._invoker = invoker
 
     def get_rect(self):
-        """Get the rectangle occupied by this window."""
         rect = Gdk.Rectangle()
-        rect.x = 0  # GTK4: Position managed by compositor
+        rect.x = 0
         rect.y = 0
         rect.width = self.get_width()
         rect.height = self.get_height()
@@ -509,12 +505,10 @@ class _PaletteWindowWidget(Gtk.Popover):
         super().popup()
         self._up = True
 
-
     def popdown(self):
         """Hide the window."""
         if not self._up:
             return
-            
         super().popdown()
         self._up = False
 
@@ -739,8 +733,8 @@ class PaletteWindow(GObject.GObject):
         self.popup(immediate=immediate)
 
     def is_up(self):
-        if self._widget is not None and hasattr(self._widget, "get_visible"):
-            return self._widget.get_visible()
+        if self._widget is not None:
+            return self._widget.get_mapped()
         return self._up
 
     def _set_effective_group_id(self, group_id):
@@ -771,36 +765,26 @@ class PaletteWindow(GObject.GObject):
         if self._widget is None:
             return
 
-        # Get size request
+        req = Gdk.Rectangle()
         try:
-            if hasattr(self._widget, "get_preferred_size"):
-                minimum, natural = self._widget.get_preferred_size()  # type: ignore
-                req = natural
-            else:
-                req = Gdk.Rectangle()
-                req.width = style.GRID_CELL_SIZE * 3
-                req.height = style.GRID_CELL_SIZE * 2
+            min_w, nat_w, _, _ = self._widget.measure(Gtk.Orientation.HORIZONTAL, -1)
+            min_h, nat_h, _, _ = self._widget.measure(Gtk.Orientation.VERTICAL, -1)
+            req.width = nat_w
+            req.height = nat_h
         except Exception:
-            req = Gdk.Rectangle()
             req.width = style.GRID_CELL_SIZE * 3
             req.height = style.GRID_CELL_SIZE * 2
 
-        # Handle menu widget size calculation
         if isinstance(self._widget, _PaletteMenuWidget):
             total_height = 0
             for child in self._widget.get_children():  # type: ignore
                 try:
-                    if hasattr(child, "get_preferred_size"):
-                        minimum, natural = child.get_preferred_size()
-                        total_height += natural.height
-                    else:
-                        total_height += style.GRID_CELL_SIZE
+                    _, nat_h, _, _ = child.measure(Gtk.Orientation.VERTICAL, -1)
+                    total_height += nat_h
                 except Exception:
                     total_height += style.GRID_CELL_SIZE
 
-            # Add border width
-            line_width = 2
-            total_height += line_width * 2
+            total_height += 4  # 2px border top + bottom
             req.height = total_height
 
         position = invoker.get_position_for_alignment(self._alignment, req)
@@ -811,14 +795,11 @@ class PaletteWindow(GObject.GObject):
             self._widget.move(position.x, position.y)
 
     def get_full_size_request(self):
-        """Get the full size request for the palette."""
         if self._widget and hasattr(self._widget, "get_preferred_size"):
             try:
-                return self._widget.get_preferred_size()[1]  # natural size
+                return self._widget.get_preferred_size()[1]
             except Exception:
                 pass
-
-        # Fallback
         req = Gdk.Rectangle()
         req.width = style.GRID_CELL_SIZE * 3
         req.height = style.GRID_CELL_SIZE * 2

--- a/src/sugar4/graphics/palettewindow.py
+++ b/src/sugar4/graphics/palettewindow.py
@@ -208,16 +208,24 @@ class _PaletteMenuWidget(Gtk.Popover):
             elif hasattr(self._invoker, "_tree_view") and self._invoker._tree_view is not None:
                 parent_widget = self._invoker._tree_view
 
-            if parent_widget is not None and not self.get_parent():
-                try:
-                    # PyGObject requires explicit Gtk.Widget call for Popover subclasses
-                    Gtk.Widget.set_parent(self, parent_widget)
-                    parent_widget.connect(
-                        'destroy',
-                        lambda w: self.unparent() if self.get_parent() else None
-                    )
-                except Exception as e:
-                    logging.warning("set_parent failed on %s: %s", parent_widget, e)
+            if parent_widget is not None:
+                native = parent_widget.get_native()
+                if native and native.get_surface():
+                    current_parent = self.get_parent()
+                    if current_parent is not None and current_parent is not parent_widget:
+                        self.unparent()
+                        current_parent = None
+                    if current_parent is None:
+                        try:
+                            Gtk.Widget.set_parent(self, parent_widget)
+                            parent_widget.connect(
+                                'destroy',
+                                lambda w: self.unparent() if self.get_parent() else None
+                            )
+                        except Exception as e:
+                            logging.warning("set_parent failed on %s: %s", parent_widget, e)
+                else:
+                    parent_widget = None
 
         if not self.get_parent():
             logging.warning("Palette popup failed: No parent widget. parent_widget was %s, invoker was %s", parent_widget if 'parent_widget' in locals() else 'Not evaluated', self._invoker)
@@ -468,16 +476,24 @@ class _PaletteWindowWidget(Gtk.Popover):
             elif hasattr(self._invoker, "_tree_view") and self._invoker._tree_view is not None:
                 parent_widget = self._invoker._tree_view
 
-            if parent_widget is not None and not self.get_parent():
-                try:
-                    # PyGObject requires explicit Gtk.Widget call for Popover subclasses
-                    Gtk.Widget.set_parent(self, parent_widget)
-                    parent_widget.connect(
-                        'destroy',
-                        lambda w: self.unparent() if self.get_parent() else None
-                    )
-                except Exception as e:
-                    logging.warning("set_parent failed on %s: %s", parent_widget, e)
+            if parent_widget is not None:
+                native = parent_widget.get_native()
+                if native and native.get_surface():
+                    current_parent = self.get_parent()
+                    if current_parent is not None and current_parent is not parent_widget:
+                        self.unparent()
+                        current_parent = None
+                    if current_parent is None:
+                        try:
+                            Gtk.Widget.set_parent(self, parent_widget)
+                            parent_widget.connect(
+                                'destroy',
+                                lambda w: self.unparent() if self.get_parent() else None
+                            )
+                        except Exception as e:
+                            logging.warning("set_parent failed on %s: %s", parent_widget, e)
+                else:
+                    parent_widget = None
 
         if not self.get_parent():
             logging.warning("Palette popup failed: No parent widget.")

--- a/src/sugar4/graphics/palettewindow.py
+++ b/src/sugar4/graphics/palettewindow.py
@@ -340,7 +340,7 @@ class _PaletteWindowWidget(Gtk.Window):
 
     def do_size_allocate(self, width, height, baseline):
         """Allocate size to the palette window and its children."""
-        Gtk.Window.do_size_allocate(self, width, height, baseline)
+        super().do_size_allocate(width, height, baseline)
 
         allocation = Gdk.Rectangle()
         allocation.x = 0
@@ -535,7 +535,7 @@ class PaletteWindow(GObject.GObject):
                 self._widget.disconnect_by_func(self.__leave_notify_cb)
 
             if self._widget is not None and hasattr(self, "_key_controller"):
-                self._widget.remove_controller(self._key_controller)
+                GLib.idle_add(self._widget.remove_controller, self._key_controller)
         except (TypeError, AttributeError):
             pass  # Already disconnected
 
@@ -1268,11 +1268,11 @@ class WidgetInvoker(Invoker):
         if self._widget:
             try:
                 if self._motion_controller:
-                    self._widget.remove_controller(self._motion_controller)
+                    GLib.idle_add(self._widget.remove_controller, self._motion_controller)
                 if self._click_controller:
-                    self._widget.remove_controller(self._click_controller)
+                    GLib.idle_add(self._widget.remove_controller, self._click_controller)
                 if self._long_press_gesture:
-                    self._widget.remove_controller(self._long_press_gesture)
+                    GLib.idle_add(self._widget.remove_controller, self._long_press_gesture)
             except Exception:
                 pass
 
@@ -1447,11 +1447,11 @@ class CursorInvoker(Invoker):
         if self.parent:
             try:
                 if self._motion_controller:
-                    self.parent.remove_controller(self._motion_controller)
+                    GLib.idle_add(self.parent.remove_controller, self._motion_controller)
                 if self._click_controller:
-                    self.parent.remove_controller(self._click_controller)
+                    GLib.idle_add(self.parent.remove_controller, self._click_controller)
                 if self._long_press_gesture:
-                    self.parent.remove_controller(self._long_press_gesture)
+                    GLib.idle_add(self.parent.remove_controller, self._long_press_gesture)
             except Exception:
                 pass
 
@@ -1606,11 +1606,11 @@ class TreeViewInvoker(Invoker):
         if self._tree_view:
             try:
                 if self._motion_controller:
-                    self._tree_view.remove_controller(self._motion_controller)
+                    GLib.idle_add(self._tree_view.remove_controller, self._motion_controller)
                 if self._click_controller:
-                    self._tree_view.remove_controller(self._click_controller)
+                    GLib.idle_add(self._tree_view.remove_controller, self._click_controller)
                 if self._long_press_gesture:
-                    self._tree_view.remove_controller(self._long_press_gesture)
+                    GLib.idle_add(self._tree_view.remove_controller, self._long_press_gesture)
             except Exception:
                 pass
 

--- a/src/sugar4/graphics/palettewindow.py
+++ b/src/sugar4/graphics/palettewindow.py
@@ -355,21 +355,20 @@ class _PaletteWindowWidget(Gtk.Popover):
 
         self._palette = palette
 
-        # Apply palette styling
         self.add_css_class("palette")
         self.add_css_class("palette-popover")
         self.set_has_arrow(False)
+        self.set_autohide(False)
 
         self._old_alloc = None
         self._invoker = None
         self._should_accept_focus = True
-        
+
         self._entered = False
         self._mouse_in_palette = False
         self._mouse_in_invoker = False
         self._up = False
 
-        # Set up event controllers for GTK4
         self._motion_controller = Gtk.EventControllerMotion()
         self._motion_controller.connect("enter", self._enter_notify_cb)
         self._motion_controller.connect("leave", self._leave_notify_cb)
@@ -465,8 +464,6 @@ class _PaletteWindowWidget(Gtk.Popover):
             parent_widget = None
             if hasattr(self._invoker, "get_widget"):
                 parent_widget = self._invoker.get_widget()
-            elif hasattr(self._invoker, "parent") and self._invoker.parent is not None:
-                parent_widget = self._invoker.parent
             elif isinstance(self._invoker, Gtk.Widget):
                 parent_widget = self._invoker
             elif hasattr(self._invoker, "_tool") and self._invoker._tool is not None:
@@ -486,10 +483,6 @@ class _PaletteWindowWidget(Gtk.Popover):
                     if current_parent is None:
                         try:
                             Gtk.Widget.set_parent(self, parent_widget)
-                            parent_widget.connect(
-                                'destroy',
-                                lambda w: self.unparent() if self.get_parent() else None
-                            )
                         except Exception as e:
                             logging.warning("set_parent failed on %s: %s", parent_widget, e)
                 else:
@@ -515,6 +508,7 @@ class _PaletteWindowWidget(Gtk.Popover):
 
         super().popup()
         self._up = True
+
 
     def popdown(self):
         """Hide the window."""

--- a/src/sugar4/graphics/palettewindow.py
+++ b/src/sugar4/graphics/palettewindow.py
@@ -209,31 +209,22 @@ class _PaletteMenuWidget(Gtk.Popover):
                 parent_widget = self._invoker._tree_view
 
             if parent_widget is not None:
-                native = parent_widget.get_native()
-                if native and native.get_surface():
-                    current_parent = self.get_parent()
-                    if current_parent is not None and current_parent is not parent_widget:
-                        self.unparent()
-                        current_parent = None
-                    if current_parent is None:
-                        try:
-                            Gtk.Widget.set_parent(self, parent_widget)
-                            parent_widget.connect(
-                                'destroy',
-                                lambda w: self.unparent() if self.get_parent() else None
-                            )
-                        except Exception as e:
-                            logging.warning("set_parent failed on %s: %s", parent_widget, e)
-                else:
-                    parent_widget = None
+                current_parent = self.get_parent()
+                if current_parent is not None and current_parent is not parent_widget:
+                    self.unparent()
+                    current_parent = None
+                if current_parent is None:
+                    try:
+                        Gtk.Widget.set_parent(self, parent_widget)
+                        parent_widget.connect(
+                            'destroy',
+                            lambda w: self.unparent() if self.get_parent() else None
+                        )
+                    except Exception as e:
+                        logging.warning("set_parent failed on %s: %s", parent_widget, e)
 
         if not self.get_parent():
             logging.warning("Palette popup failed: No parent widget. parent_widget was %s, invoker was %s", parent_widget if 'parent_widget' in locals() else 'Not evaluated', self._invoker)
-            return
-
-        native = self.get_parent().get_native()
-        if not native or not native.get_surface():
-            logging.warning("Palette popup failed: Parent is not in a toplevel window.")
             return
 
         self._entered = False
@@ -470,27 +461,18 @@ class _PaletteWindowWidget(Gtk.Popover):
                 parent_widget = self._invoker._tree_view
 
             if parent_widget is not None:
-                native = parent_widget.get_native()
-                if native and native.get_surface():
-                    current_parent = self.get_parent()
-                    if current_parent is not None and current_parent is not parent_widget:
-                        self.unparent()
-                        current_parent = None
-                    if current_parent is None:
-                        try:
-                            Gtk.Widget.set_parent(self, parent_widget)
-                        except Exception as e:
-                            logging.warning("set_parent failed on %s: %s", parent_widget, e)
-                else:
-                    parent_widget = None
+                current_parent = self.get_parent()
+                if current_parent is not None and current_parent is not parent_widget:
+                    self.unparent()
+                    current_parent = None
+                if current_parent is None:
+                    try:
+                        Gtk.Widget.set_parent(self, parent_widget)
+                    except Exception as e:
+                        logging.warning("set_parent failed on %s: %s", parent_widget, e)
 
         if not self.get_parent():
             logging.warning("Palette popup failed: No parent widget.")
-            return
-
-        native = self.get_parent().get_native()
-        if not native or not native.get_surface():
-            logging.warning("Palette popup failed: Parent is not in a toplevel window.")
             return
 
         self._entered = False

--- a/src/sugar4/graphics/palettewindow.py
+++ b/src/sugar4/graphics/palettewindow.py
@@ -45,7 +45,7 @@ print = debug_print
 
 
 def _get_pointer_position(widget):
-    """Get pointer position relative to widget ."""
+    """Get pointer position relative to widget."""
     global _pointer
     if _pointer is None:
         display = widget.get_display()
@@ -61,8 +61,20 @@ def _get_pointer_position(widget):
         return (0, 0)
 
     try:
-        device_position = surface.get_device_position(_pointer)
-        return (device_position[1], device_position[2])  # x, y
+        ret = surface.get_device_position(_pointer)
+        if len(ret) == 4:
+            _, x, y, _ = ret
+        else:
+            x, y, _ = ret
+
+        import gi
+        gi.require_version('Graphene', '1.0')
+        from gi.repository import Graphene
+        p = Graphene.Point().init(x, y)
+        success, tp = native.compute_point(widget, p)
+        if success:
+            return (tp.x, tp.y)
+        return (x, y)
     except Exception:
         return (0, 0)
 
@@ -111,6 +123,7 @@ class _PaletteMenuWidget(Gtk.Popover):
         
         self.add_css_class("palette")
         self.add_css_class("palette-popover")
+        self.set_has_arrow(False)
 
         # container for menu items
         self._menu_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
@@ -349,6 +362,7 @@ class _PaletteWindowWidget(Gtk.Popover):
         # Apply palette styling
         self.add_css_class("palette")
         self.add_css_class("palette-popover")
+        self.set_has_arrow(False)
 
         self._old_alloc = None
         self._invoker = None
@@ -364,6 +378,11 @@ class _PaletteWindowWidget(Gtk.Popover):
         self._motion_controller.connect("enter", self._enter_notify_cb)
         self._motion_controller.connect("leave", self._leave_notify_cb)
         self.add_controller(self._motion_controller)
+
+        self.connect("closed", self._on_closed)
+
+    def _on_closed(self, popover):
+        self._up = False
 
     def get_rect(self):
         """Get the bounding box of the palette."""
@@ -1419,6 +1438,15 @@ class WidgetInvoker(Invoker):
         self.notify_mouse_enter()
 
     def __leave_notify_event_cb(self, controller):
+        if self._widget:
+            try:
+                x, y = _get_pointer_position(self._widget)
+                width = self._widget.get_width()
+                height = self._widget.get_height()
+                if 0 <= x <= width and 0 <= y <= height:
+                    return
+            except Exception:
+                pass
         self.notify_mouse_leave()
 
     def __button_release_event_cb(self, gesture, n_press, x, y):
@@ -1558,6 +1586,15 @@ class CursorInvoker(Invoker):
         self.notify_mouse_enter()
 
     def __leave_notify_event_cb(self, controller):
+        if self.parent:
+            try:
+                x, y = _get_pointer_position(self.parent)
+                width = self.parent.get_width()
+                height = self.parent.get_height()
+                if 0 <= x <= width and 0 <= y <= height:
+                    return
+            except Exception:
+                pass
         self.notify_mouse_leave()
 
     def __button_release_event_cb(self, gesture, n_press, x, y):
@@ -1781,11 +1818,16 @@ class TreeViewInvoker(Invoker):
 
         button = gesture.get_current_button()
         if button == 1:
+            # Deny the sequence so TreeView's internal row-activation gesture receives it
+            sequence = gesture.get_current_sequence()
+            if sequence:
+                gesture.set_state(sequence, Gtk.EventSequenceState.DENIED)
+            
             # Left mouse button
             if self.palette is not None:
                 self.palette.popdown(immediate=True)
 
-            # Handle cell renderer click
+            # Handle cell renderer click manually because GTK4 TreeView single-click doesn't reliably trigger do_activate
             if column and hasattr(column, "get_cells"):
                 cells = column.get_cells()
                 if cells:
@@ -1796,6 +1838,7 @@ class TreeViewInvoker(Invoker):
                         and isinstance(cellrenderer, CellRendererIcon)
                     ):
                         cellrenderer.emit("clicked", path)  # type: ignore
+
             return False
         elif button == 3:
             # Right mouse button

--- a/src/sugar4/graphics/palettewindow.py
+++ b/src/sugar4/graphics/palettewindow.py
@@ -209,26 +209,15 @@ class _PaletteMenuWidget(Gtk.Popover):
                 parent_widget = self._invoker._tree_view
 
             if parent_widget is not None and not self.get_parent():
-                # Try direct parent widget first, then root as fallback.
-                # Do NOT use a loop that swallows exceptions — partial-root
-                # states cause the GTK assertion (priv->root == NULL).
-                root = parent_widget.get_root()
-                candidates = [parent_widget]
-                if root is not None and root is not parent_widget:
-                    candidates.append(root)
-                for candidate in candidates:
-                    try:
-                        # PyGObject requires explicit Gtk.Widget call for Popover subclasses
-                        Gtk.Widget.set_parent(self, candidate)
-                    except Exception as e:
-                        logging.warning("set_parent failed on %s: %s", candidate, e)
-                        continue
-                    if self.get_parent():
-                        candidate.connect(
-                            'destroy',
-                            lambda w: self.unparent() if self.get_parent() else None
-                        )
-                        break
+                try:
+                    # PyGObject requires explicit Gtk.Widget call for Popover subclasses
+                    Gtk.Widget.set_parent(self, parent_widget)
+                    parent_widget.connect(
+                        'destroy',
+                        lambda w: self.unparent() if self.get_parent() else None
+                    )
+                except Exception as e:
+                    logging.warning("set_parent failed on %s: %s", parent_widget, e)
 
         if not self.get_parent():
             logging.warning("Palette popup failed: No parent widget. parent_widget was %s, invoker was %s", parent_widget if 'parent_widget' in locals() else 'Not evaluated', self._invoker)
@@ -304,7 +293,6 @@ class _PaletteMenuWidget(Gtk.Popover):
         if not self._invoker:
             return False
 
-        # Check if click is in invoker area
         try:
             native = self.get_native()
             if native and native.get_surface():
@@ -410,7 +398,6 @@ class _PaletteWindowWidget(Gtk.Popover):
 
     def get_origin(self):
         """Get the origin position of the window."""
-        # GTK4: Window position is managed by compositor
         return (0, 0)
         
     def move(self, x, y):
@@ -482,26 +469,15 @@ class _PaletteWindowWidget(Gtk.Popover):
                 parent_widget = self._invoker._tree_view
 
             if parent_widget is not None and not self.get_parent():
-                # Try direct parent widget first, then root as fallback.
-                # Do NOT use a loop that swallows exceptions — partial-root
-                # states cause the GTK assertion (priv->root == NULL).
-                root = parent_widget.get_root()
-                candidates = [parent_widget]
-                if root is not None and root is not parent_widget:
-                    candidates.append(root)
-                for candidate in candidates:
-                    try:
-                        # PyGObject requires explicit Gtk.Widget call for Popover subclasses
-                        Gtk.Widget.set_parent(self, candidate)
-                    except Exception as e:
-                        logging.warning("set_parent failed on %s: %s", candidate, e)
-                        continue
-                    if self.get_parent():
-                        candidate.connect(
-                            'destroy',
-                            lambda w: self.unparent() if self.get_parent() else None
-                        )
-                        break
+                try:
+                    # PyGObject requires explicit Gtk.Widget call for Popover subclasses
+                    Gtk.Widget.set_parent(self, parent_widget)
+                    parent_widget.connect(
+                        'destroy',
+                        lambda w: self.unparent() if self.get_parent() else None
+                    )
+                except Exception as e:
+                    logging.warning("set_parent failed on %s: %s", parent_widget, e)
 
         if not self.get_parent():
             logging.warning("Palette popup failed: No parent widget.")
@@ -932,12 +908,70 @@ class PaletteWindow(GObject.GObject):
             self.popdown()
             return True
 
+    def _check_mouse_outside(self):
+        if not self._up:
+            return False
+
+        if not self._invoker or getattr(self._invoker, "locked", False):
+            return False
+
+        if not self._widget:
+            return False
+
+        native = self._widget.get_native()
+        if not native or not native.get_surface():
+            return True
+
+        try:
+            surface = native.get_surface()
+            device_position = surface.get_device_position(_pointer)
+            if not device_position:
+                return True
+            root_x, root_y = device_position[1], device_position[2]
+        except Exception:
+            return True
+
+        from gi.repository import Graphene
+
+        in_invoker = False
+        invoker_widget = self._invoker.get_widget()
+        if invoker_widget:
+            try:
+                success, p_invoker = native.compute_point(
+                    invoker_widget, Graphene.Point().init(root_x, root_y)
+                )
+                if success:
+                    in_invoker = (0 <= p_invoker.x <= invoker_widget.get_width() and
+                                  0 <= p_invoker.y <= invoker_widget.get_height())
+            except Exception:
+                pass
+
+        in_popover = False
+        try:
+            success, p_popover = native.compute_point(
+                self._widget, Graphene.Point().init(root_x, root_y)
+            )
+            if success:
+                in_popover = (0 <= p_popover.x <= self._widget.get_width() and
+                              0 <= p_popover.y <= self._widget.get_height())
+        except Exception:
+            pass
+
+        if not in_invoker and not in_popover:
+            self.popdown()
+            return False
+
+        return True
+
     def __show_cb(self, widget):
         if self._invoker is not None and hasattr(self._invoker, "notify_popup"):
             self._invoker.notify_popup()
 
         self._up = True
         self.emit("popup")
+
+        # Start tracking pointer to auto-hide palette when mouse leaves both areas
+        GLib.timeout_add(100, self._check_mouse_outside)
 
     def __hide_cb(self, widget):
         if self._invoker and hasattr(self._invoker, "notify_popdown"):
@@ -1400,7 +1434,6 @@ class WidgetInvoker(Invoker):
         if not self._widget:
             return Gdk.Rectangle()
 
-        # In GTK4, Popovers are positioned relative to their parent widget.
         # Since we attach the Popover to self._widget, pointing_to must be
         # in local widget coordinates.
         width = self._widget.get_width()
@@ -1427,7 +1460,6 @@ class WidgetInvoker(Invoker):
 
         gap = _calculate_gap(self.get_rect(), palette.get_rect())
         if gap:
-            # GTK4: Would need to use snapshot API for drawing
             # TODO
             pass
 
@@ -1790,6 +1822,7 @@ class TreeViewInvoker(Invoker):
 
             if self.palette is not None:
                 self.palette.popdown(immediate=True)
+                self.palette.destroy()
                 self.palette = None
 
             self.notify_mouse_enter()
@@ -1826,6 +1859,8 @@ class TreeViewInvoker(Invoker):
             # Left mouse button
             if self.palette is not None:
                 self.palette.popdown(immediate=True)
+                self.palette.destroy()
+                self.palette = None
 
             # Handle cell renderer click manually because GTK4 TreeView single-click doesn't reliably trigger do_activate
             if column and hasattr(column, "get_cells"):
@@ -1837,7 +1872,7 @@ class TreeViewInvoker(Invoker):
                         and cellrenderer is not None
                         and isinstance(cellrenderer, CellRendererIcon)
                     ):
-                        cellrenderer.emit("clicked", path)  # type: ignore
+                        cellrenderer.emit("clicked", path.to_string())  # type: ignore
 
             return False
         elif button == 3:

--- a/src/sugar4/graphics/radiopalette.py
+++ b/src/sugar4/graphics/radiopalette.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2009, Aleksey Lim
+﻿# Copyright (C) 2009, Aleksey Lim
 # Copyright (C) 2025 MostlyK
 #
 # This library is free software; you can redistribute it and/or
@@ -93,7 +93,6 @@ class RadioMenuButton(ToolButton):
         invoker = self.get_palette_invoker()
         print(f"Got palette invoker: {invoker}")
         if invoker:
-            # In GTK4, we handle toggle behavior differently
             invoker.set_toggle_palette(True)
             print("Set toggle_palette to True")
 
@@ -236,7 +235,6 @@ class RadioPalette(Palette):
     def _on_button_clicked(self, button):
         print(f"RadioPalette._on_button_clicked called with button: {button}")
 
-        # First, make sure this button is active and others are not
         child = self.button_box.get_first_child()
         while child:
             if hasattr(child, "set_active"):

--- a/src/sugar4/graphics/radiotoolbutton.py
+++ b/src/sugar4/graphics/radiotoolbutton.py
@@ -87,20 +87,17 @@ class RadioToolButton(ToolButton):
     def _apply_radio_styling(self):
         css = """
         .radio-tool-button {
-            border-radius: 4px;
-            margin: 1px;
         }
 
         .radio-tool-button:checked,
         .radio-tool-button.active {
-            background: alpha(@theme_selected_bg_color, 0.2);
-            border: 1px solid @theme_selected_bg_color;
+            background-color: %s;
         }
 
         .radio-tool-button:hover:not(.active) {
             background: alpha(@theme_fg_color, 0.05);
         }
-        """
+        """ % style.COLOR_BUTTON_GREY.get_html()
         style.apply_css_to_widget(self, css)
 
     def _on_clicked(self, button):

--- a/src/sugar4/graphics/scrollingdetector.py
+++ b/src/sugar4/graphics/scrollingdetector.py
@@ -15,19 +15,18 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-'''
+"""
 ScrollingDetector emits signals when a ScrolledWindow starts and
 finish scrolling. Other widgets can use that information to
 avoid doing performance-expensive operations.
-'''
+"""
 
-
-from gi.repository import GObject
 from gi.repository import GLib
+from gi.repository import GObject
 
 
 class ScrollingDetector(GObject.GObject):
-    '''
+    """
     The scrolling detector sends signals when a scrolled window is scrolled and
     when a scrolled window stops scrolling. Only one `scroll-start`
     signal will be emitted until scrolling stops.
@@ -42,46 +41,48 @@ class ScrollingDetector(GObject.GObject):
 
         timeout (int): time in milliseconds to establish the interval for which
             scrolling is detected
-    '''
+    """
 
-    scroll_start_signal = GObject.Signal('scroll-start')
-    scroll_end_signal = GObject.Signal('scroll-end')
+    __gsignals__ = {
+        "scroll-start": (GObject.SignalFlags.RUN_FIRST, None, ()),
+        "scroll-end": (GObject.SignalFlags.RUN_FIRST, None, ()),
+    }
 
     def __init__(self, scrolled_window, timeout=100):
+        super().__init__()
         self._scrolled_window = scrolled_window
         self._timeout = timeout
         self.is_scrolling = False
         self._prev_value = 0
 
         self.connect_scrolled_window()
-        GObject.GObject.__init__(self)
 
     def connect_scrolled_window(self):
-        '''
+        """
         Connects scrolling detector to a scrolled window.
         Detects scrolling when the vertical scrollbar
         adjustment value is changed
 
         Should be used to link an instance of a scrolling detector
         to a Scrolled Window, after setting scrolled_window
-        '''
+        """
         adj = self._scrolled_window.get_vadjustment()
-        adj.connect('value-changed', self._value_changed_cb)
+        adj.connect("value-changed", self._value_changed_cb)
 
     def _check_scroll_cb(self, adj):
-        if (adj.props.value == self._prev_value):
+        if adj.props.value == self._prev_value:
             self.is_scrolling = False
-            self.scroll_end_signal.emit()
+            self.emit("scroll-end")
             return False
 
         self._prev_value = adj.props.value
         return True
 
     def _value_changed_cb(self, adj):
-        if (self.is_scrolling):
+        if self.is_scrolling:
             return
 
         self.is_scrolling = True
-        self.scroll_start_signal.emit()
+        self.emit("scroll-start")
         self._prev_value = adj.props.value
         GLib.timeout_add(self._timeout, self._check_scroll_cb, adj)

--- a/src/sugar4/graphics/style.py
+++ b/src/sugar4/graphics/style.py
@@ -198,15 +198,11 @@ class Color:
 
     def get_gdk_color(self):
         """
-        Returns GDK standard color (deprecated in GTK4).
-        Maintained for compatibility.
+        Returns GDK standard color (removed in GTK4).
+        Maintained for API compatibility — always returns None.
+        Use get_gdk_rgba() instead.
         """
-        if not GTK_AVAILABLE:
-            return None
-        logging.warning("get_gdk_color is deprecated in GTK4, use get_gdk_rgba instead")
-        return Gdk.Color(
-            int(self._r * 65535), int(self._g * 65535), int(self._b * 65535)
-        )
+        return None
 
     def get_html(self) -> str:
         """

--- a/src/sugar4/graphics/style.py
+++ b/src/sugar4/graphics/style.py
@@ -302,13 +302,12 @@ def apply_css_to_widget(widget, css: str) -> None:
             _CSS_COUNTER += 1
             class_name = f"sugar-dynamic-style-{_CSS_COUNTER}"
 
-            # Wrap CSS rule targeting class_name
-            if css.startswith("*"):
-                scoped_css = css.replace("*", f".{class_name}", 1)
-            elif not css.startswith("."):
-                scoped_css = f".{class_name} {{ {css} }}"
-            else:
+            # If css already contains full selector block(s) with '{', use as-is.
+            # Otherwise, wrap property declarations in dynamic class selector.
+            if "{" in css:
                 scoped_css = css
+            else:
+                scoped_css = f".{class_name} {{ {css} }}"
 
             css_provider = Gtk.CssProvider()
             css_provider.load_from_string(scoped_css)

--- a/src/sugar4/graphics/style.py
+++ b/src/sugar4/graphics/style.py
@@ -273,10 +273,10 @@ def zoom(units: float) -> int:
 
 def apply_css_to_widget(widget, css: str) -> None:
     """
-    Apply CSS styling to a widget.
+    Apply CSS styling globally (GTK4 doesn't support per-widget CSS providers).
 
     Args:
-        widget: Widget to style
+        widget: Widget to style (ignored in GTK4, CSS is global)
         css (str): CSS string to apply
     """
     if not GTK_AVAILABLE:
@@ -286,8 +286,11 @@ def apply_css_to_widget(widget, css: str) -> None:
         css_provider = Gtk.CssProvider()
         css_provider.load_from_string(css)
 
-        context = widget.get_style_context()
-        context.add_provider(css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+        Gtk.StyleContext.add_provider_for_display(
+            Gdk.Display.get_default(),
+            css_provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
     except Exception as e:
         logging.warning(f"Failed to apply CSS: {e}")
 

--- a/src/sugar4/graphics/style.py
+++ b/src/sugar4/graphics/style.py
@@ -267,28 +267,68 @@ def zoom(units: float) -> int:
     return round(ZOOM_FACTOR * units)
 
 
+_CSS_CACHE: dict = {}
+_CSS_COUNTER: int = 0
+
+
 def apply_css_to_widget(widget, css: str) -> None:
     """
-    Apply CSS styling globally (GTK4 doesn't support per-widget CSS providers).
+    Apply CSS styling using modern GTK4 add_css_class API with provider caching.
 
     Args:
-        widget: Widget to style (ignored in GTK4, CSS is global)
-        css (str): CSS string to apply
+        widget: Gtk.Widget to style
+        css (str): CSS snippet or class name
     """
-    if not GTK_AVAILABLE:
+    global _CSS_COUNTER
+    if not GTK_AVAILABLE or widget is None:
+        return
+
+    css = css.strip()
+    if not css:
+        return
+
+    # If it's a simple CSS class name (e.g. "toolbar" or ".toolbar")
+    if not ("{" in css or "}" in css or ":" in css):
+        class_name = css.lstrip('.')
+        if hasattr(widget, 'add_css_class'):
+            widget.add_css_class(class_name)
         return
 
     try:
-        css_provider = Gtk.CssProvider()
-        css_provider.load_from_string(css)
+        # Check cache for identical CSS rule
+        if css in _CSS_CACHE:
+            class_name, _ = _CSS_CACHE[css]
+        else:
+            _CSS_COUNTER += 1
+            class_name = f"sugar-dynamic-style-{_CSS_COUNTER}"
 
-        Gtk.StyleContext.add_provider_for_display(
-            Gdk.Display.get_default(),
-            css_provider,
-            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
-        )
+            # Wrap CSS rule targeting class_name
+            if css.startswith("*"):
+                scoped_css = css.replace("*", f".{class_name}", 1)
+            elif not css.startswith("."):
+                scoped_css = f".{class_name} {{ {css} }}"
+            else:
+                scoped_css = css
+
+            css_provider = Gtk.CssProvider()
+            css_provider.load_from_string(scoped_css)
+
+            display = Gdk.Display.get_default()
+            if display:
+                Gtk.StyleContext.add_provider_for_display(
+                    display,
+                    css_provider,
+                    Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+                )
+
+            _CSS_CACHE[css] = (class_name, css_provider)
+
+        if hasattr(widget, 'add_css_class'):
+            widget.add_css_class(class_name)
     except Exception as e:
-        logging.warning(f"Failed to apply CSS: {e}")
+        logging.warning(f"Failed to apply CSS to widget: {e}")
+
+
 
 
 _BASE_CSS = """

--- a/src/sugar4/graphics/style.py
+++ b/src/sugar4/graphics/style.py
@@ -295,6 +295,40 @@ def apply_css_to_widget(widget, css: str) -> None:
         logging.warning(f"Failed to apply CSS: {e}")
 
 
+_BASE_CSS = """
+window, box, grid {
+    padding: 0px;
+}
+button {
+    padding: 4px;
+    margin: 0px;
+    min-height: 24px;
+    min-width: 24px;
+}
+toolbar {
+    padding: 0px;
+}
+toolbar button {
+    padding: 2px;
+}
+"""
+
+def _init_global_css():
+    if not GTK_AVAILABLE:
+        return
+    try:
+        css_provider = Gtk.CssProvider()
+        css_provider.load_from_string(_BASE_CSS)
+        Gtk.StyleContext.add_provider_for_display(
+            Gdk.Display.get_default(),
+            css_provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
+    except Exception as e:
+        logging.warning(f"Failed to apply base CSS: {e}")
+
+_init_global_css()
+
 ZOOM_FACTOR = _compute_zoom_factor()  #: Scale factor, as float (eg. 0.72, 1.0)
 
 DEFAULT_SPACING = zoom(15)  #: Spacing is placed in-between elements

--- a/src/sugar4/graphics/style.py
+++ b/src/sugar4/graphics/style.py
@@ -312,6 +312,14 @@ toolbar button {
     padding: 2px;
 }
 
+/* Tray button styling to resolve layout overflow in GTK4 */
+button.tray-button, .tray-button {
+    margin: 0px;
+    padding: 0px;
+    min-width: 32px;
+    min-height: 32px;
+}
+
 /* Palette styling for GTK4 */
 .palette, SugarPaletteMenuWidget, SugarPaletteWindowWidget {
     background-color: #000000;
@@ -322,7 +330,7 @@ toolbar button {
 .palette * {
     color: #FFFFFF;
 }
-.palette *:insensitive {
+.palette *:disabled {
     color: #808080;
 }
 

--- a/src/sugar4/graphics/style.py
+++ b/src/sugar4/graphics/style.py
@@ -268,7 +268,7 @@ def zoom(units: float) -> int:
     Args:
         units (int or float): Size of item at full size
     """
-    return int(ZOOM_FACTOR * units)
+    return round(ZOOM_FACTOR * units)
 
 
 def apply_css_to_widget(widget, css: str) -> None:
@@ -310,6 +310,27 @@ toolbar {
 }
 toolbar button {
     padding: 2px;
+}
+
+/* Palette styling for GTK4 */
+.palette, SugarPaletteMenuWidget, SugarPaletteWindowWidget {
+    background-color: #000000;
+    color: #FFFFFF;
+    border-radius: 11px;
+    border: 2px solid #808080;
+}
+.palette * {
+    color: #FFFFFF;
+}
+.palette *:insensitive {
+    color: #808080;
+}
+
+/* Search bar and toolbar entry styling */
+.toolbar entry, .toolbar .entry {
+    background-color: #ffffff;
+    color: #000000;
+    border: 1px solid #808080;
 }
 """
 

--- a/src/sugar4/graphics/toggletoolbutton.py
+++ b/src/sugar4/graphics/toggletoolbutton.py
@@ -99,6 +99,11 @@ class ToggleToolButton(Gtk.ToggleButton):
         self._palette_invoker = ToolInvoker(self)
         self._accelerator = None
 
+        self.add_css_class("toolbar-button")
+        self.add_css_class("flat")
+        self.set_has_frame(False)
+        self.set_can_focus(True)
+
         if icon_name:
             self.set_icon_name(icon_name)
 
@@ -106,6 +111,44 @@ class ToggleToolButton(Gtk.ToggleButton):
         self.connect("notify::root", _on_root_changed)
         self.connect("map", self._on_mapped)
         self.connect("destroy", self.__destroy_cb)
+
+        self._apply_toolbar_button_css()
+
+    def _apply_toolbar_button_css(self):
+        css = """
+        .toolbar-button {
+            border-radius: 6px;
+            margin: 2px;
+            padding: 6px;
+            min-width: 32px;
+            min-height: 32px;
+            background: transparent;
+            border: none;
+        }
+
+        .toolbar-button:hover {
+            background: alpha(currentColor, 0.1);
+        }
+
+        .toolbar-button:active,
+        .toolbar-button:checked {
+            background: alpha(currentColor, 0.2);
+            border: 1px solid alpha(currentColor, 0.3);
+            box-shadow: none;
+        }
+
+        .toolbar-button:focus {
+            outline: 2px solid rgb(53, 132, 228);
+            outline-offset: 2px;
+        }
+        """
+        try:
+            css_provider = Gtk.CssProvider()
+            css_provider.load_from_string(css)
+            self.get_style_context().add_provider(css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+        except Exception as e:
+            import logging
+            logging.warning(f"Could not apply toolbar button CSS: {e}")
 
     def _on_mapped(self, widget):
         """Called when widget is mapped (visible and added to window)."""

--- a/src/sugar4/graphics/toggletoolbutton.py
+++ b/src/sugar4/graphics/toggletoolbutton.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2007, Red Hat, Inc.
+﻿# Copyright (C) 2007, Red Hat, Inc.
 # Copyright (C) 2012, Daniel Francis
 # Copyright (C) 2025 MostlyK
 #
@@ -256,7 +256,6 @@ class ToggleToolButton(Gtk.ToggleButton):
         """
         Render the toggle tool button using snapshot-based drawing.
         """
-        # Snapshot child
         child = self.get_first_child()
         while child is not None:
             self.snapshot_child(child, snapshot)
@@ -275,6 +274,5 @@ class ToggleToolButton(Gtk.ToggleButton):
         # Call parent implementation first to handle toggle behavior
         Gtk.ToggleButton.do_clicked(self)
 
-        # Then handle palette
         if self.palette:
             self.palette.popdown(True)

--- a/src/sugar4/graphics/toggletoolbutton.py
+++ b/src/sugar4/graphics/toggletoolbutton.py
@@ -1,4 +1,4 @@
-﻿# Copyright (C) 2007, Red Hat, Inc.
+# Copyright (C) 2007, Red Hat, Inc.
 # Copyright (C) 2012, Daniel Francis
 # Copyright (C) 2025 MostlyK
 #
@@ -110,7 +110,7 @@ class ToggleToolButton(Gtk.ToggleButton):
         # Connect to root changes and map signal to setup accelerator
         self.connect("notify::root", _on_root_changed)
         self.connect("map", self._on_mapped)
-        self.connect("destroy", self.__destroy_cb)
+        self.connect("unrealize", self.__destroy_cb)
 
         self._apply_toolbar_button_css()
 

--- a/src/sugar4/graphics/toggletoolbutton.py
+++ b/src/sugar4/graphics/toggletoolbutton.py
@@ -213,9 +213,11 @@ class ToggleToolButton(Gtk.ToggleButton):
         """
         Render the toggle tool button using snapshot-based drawing.
         """
-        # Use snapshot-based rendering instead of legacy draw methods
-        # For now, just call the parent implementation
-        Gtk.ToggleButton.do_snapshot(self, snapshot)
+        # Snapshot child
+        child = self.get_first_child()
+        while child is not None:
+            self.snapshot_child(child, snapshot)
+            child = child.get_next_sibling()
 
         # Custom drawing can be implemented here using the snapshot API
         # if self.palette and self.palette.is_up():

--- a/src/sugar4/graphics/toggletoolbutton.py
+++ b/src/sugar4/graphics/toggletoolbutton.py
@@ -110,7 +110,6 @@ class ToggleToolButton(Gtk.ToggleButton):
         # Connect to root changes and map signal to setup accelerator
         self.connect("notify::root", _on_root_changed)
         self.connect("map", self._on_mapped)
-        self.connect("unrealize", self.__destroy_cb)
 
         self._apply_toolbar_button_css()
 
@@ -154,16 +153,21 @@ class ToggleToolButton(Gtk.ToggleButton):
         """Called when widget is mapped (visible and added to window)."""
         _add_accelerator(self)
 
-    def __destroy_cb(self, icon):
-        if self._palette_invoker is not None:
+    def do_dispose(self):
+        if getattr(self, "_palette_invoker", None) is not None:
             self._palette_invoker.detach()
+            self._palette_invoker = None
         # Remove accelerator action
         if hasattr(self, "_accel_action_name"):
             root = self.get_root()
             if root:
-                app = root.get_application()
+                app = getattr(root, "get_application", lambda: None)()
                 if app:
-                    app.remove_action(self._accel_action_name)
+                    try:
+                        app.remove_action(self._accel_action_name)
+                    except:
+                        pass
+        super().do_dispose()
 
     def set_icon_name(self, icon_name):
         """

--- a/src/sugar4/graphics/toolbarbox.py
+++ b/src/sugar4/graphics/toolbarbox.py
@@ -77,11 +77,13 @@ class ToolbarButton(ToolButton):
 
     def _hierarchy_changed_cb(self, widget, pspec):
         parent = self.get_parent()
-        if hasattr(parent, "owner"):
-            if self.page_widget and self.get_root():
-                self._unparent()
+        if self.page_widget and self.get_root():
+            self._unparent()
+            if hasattr(parent, "owner"):
                 parent.owner.append(self.page_widget)
-                self.set_expanded(False)
+                self.page_widget.set_visible(self._expanded)
+            else:
+                self._move_page_to_palette()
 
     def get_toolbar_box(self):
         parent = self.get_parent()
@@ -494,7 +496,7 @@ def _setup_page(page_widget, color, hpad):
 
 
 def _embed_page(page_widget, page):
-    page.show()
+    page.set_visible(True)
 
     # Box instead of Alignment
     container = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
@@ -503,10 +505,10 @@ def _embed_page(page_widget, page):
     # The toolbar should not absorb extra vertical space; keep it compact.
     container.set_vexpand(False)
     container.append(page)
-    container.show()
+    container.set_visible(True)
 
     page_widget.append(container)
-    page_widget.show()
+    page_widget.set_visible(True)
 
     return (page_widget, container)
 

--- a/src/sugar4/graphics/toolbarbox.py
+++ b/src/sugar4/graphics/toolbarbox.py
@@ -1,4 +1,4 @@
-﻿# Copyright (C) 2009, Aleksey Lim
+# Copyright (C) 2009, Aleksey Lim
 # Copyright (C) 2025 MostlyK
 #
 # This library is free software; you can redistribute it and/or
@@ -444,7 +444,13 @@ class _Box(Gtk.Box):
             self.snapshot_child(child, snapshot)
             child = child.get_next_sibling()
 
-        button_alloc = self._toolbar_button.get_allocation()
+        # In GTK4 get_allocation() is removed; translate button coordinates
+        # relative to self, then use get_width() for the button width.
+        btn_x = 0
+        btn_w = self._toolbar_button.get_width()
+        ok, bx, _by = self._toolbar_button.translate_coordinates(self, 0, 0)
+        if ok:
+            btn_x = bx
         my_width = self.get_width()
 
         if my_width > 0:
@@ -457,15 +463,14 @@ class _Box(Gtk.Box):
             line_width = style.FOCUS_LINE_WIDTH * 2
 
             rect1 = Graphene.Rect()
-            rect1.init(0, 0, button_alloc.x + style.FOCUS_LINE_WIDTH, line_width)
+            rect1.init(0, 0, btn_x + style.FOCUS_LINE_WIDTH, line_width)
             snapshot.append_color(color, rect1)
 
             rect2 = Graphene.Rect()
             rect2.init(
-                button_alloc.x + button_alloc.width - style.FOCUS_LINE_WIDTH,
+                btn_x + btn_w - style.FOCUS_LINE_WIDTH,
                 0,
-                my_width
-                - (button_alloc.x + button_alloc.width - style.FOCUS_LINE_WIDTH),
+                my_width - (btn_x + btn_w - style.FOCUS_LINE_WIDTH),
                 line_width,
             )
             snapshot.append_color(color, rect2)

--- a/src/sugar4/graphics/toolbarbox.py
+++ b/src/sugar4/graphics/toolbarbox.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2009, Aleksey Lim
+﻿# Copyright (C) 2009, Aleksey Lim
 # Copyright (C) 2025 MostlyK
 #
 # This library is free software; you can redistribute it and/or
@@ -188,7 +188,6 @@ class ToolbarButton(ToolButton):
 
     def do_snapshot(self, snapshot):
         """GTK4 drawing implementation with arrow indicator."""
-        # Snapshot child
         child = self.get_first_child()
         while child is not None:
             self.snapshot_child(child, snapshot)
@@ -243,7 +242,6 @@ class ToolbarBox(Gtk.Box):
 
         self._toolbar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         self._toolbar.owner = self
-        # GTK4: Box doesn't have a "remove" signal, we'll handle removal differently
 
         self._toolbar_widget, self._toolbar_alignment = _embed_page(
             Gtk.Box(orientation=Gtk.Orientation.VERTICAL), self._toolbar
@@ -299,7 +297,6 @@ class ToolbarBox(Gtk.Box):
     def set_padding(self, pad):
         self._padding = pad
         if self._toolbar_alignment:
-            # GTK4: Use margins instead of alignment padding
             self._toolbar_alignment.set_margin_start(pad)
             self._toolbar_alignment.set_margin_end(pad)
 
@@ -442,7 +439,6 @@ class _Box(Gtk.Box):
 
     def do_snapshot(self, snapshot):
         """Render palette using snapshot drawing."""
-        # Snapshot child
         child = self.get_first_child()
         while child is not None:
             self.snapshot_child(child, snapshot)

--- a/src/sugar4/graphics/toolbarbox.py
+++ b/src/sugar4/graphics/toolbarbox.py
@@ -186,7 +186,11 @@ class ToolbarButton(ToolButton):
 
     def do_snapshot(self, snapshot):
         """GTK4 drawing implementation with arrow indicator."""
-        Gtk.Widget.do_snapshot(self, snapshot)
+        # Snapshot child
+        child = self.get_first_child()
+        while child is not None:
+            self.snapshot_child(child, snapshot)
+            child = child.get_next_sibling()
 
         width = self.get_width()
         height = self.get_height()
@@ -436,7 +440,11 @@ class _Box(Gtk.Box):
 
     def do_snapshot(self, snapshot):
         """Render palette using snapshot drawing."""
-        Gtk.Widget.do_snapshot(self, snapshot)
+        # Snapshot child
+        child = self.get_first_child()
+        while child is not None:
+            self.snapshot_child(child, snapshot)
+            child = child.get_next_sibling()
 
         button_alloc = self._toolbar_button.get_allocation()
         my_width = self.get_width()

--- a/src/sugar4/graphics/toolbox.py
+++ b/src/sugar4/graphics/toolbox.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2007, Red Hat, Inc.
+﻿# Copyright (C) 2007, Red Hat, Inc.
 # Copyright (C) 2025 MostlyK
 #
 # This library is free software; you can redistribute it and/or
@@ -205,7 +205,6 @@ class Toolbox(Gtk.Box):
 
         page = self._notebook.get_nth_page(index)
         if page and isinstance(page, Gtk.Box):
-            # Return the first child (the actual toolbar)
             child = page.get_first_child()
             return child
         return page

--- a/src/sugar4/graphics/toolbutton.py
+++ b/src/sugar4/graphics/toolbutton.py
@@ -139,7 +139,7 @@ class ToolButton(Gtk.Button):
         self.set_can_focus(True)
 
         self._palette_invoker = ToolInvoker()
-        self._palette_invoker.attach(self)
+        self._palette_invoker.attach_tool(self)
 
         self._content_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         self._content_box.set_halign(Gtk.Align.CENTER)

--- a/src/sugar4/graphics/toolbutton.py
+++ b/src/sugar4/graphics/toolbutton.py
@@ -419,8 +419,22 @@ class ToolButton(Gtk.Button):
 
     def do_snapshot(self, snapshot):
         """Render tool button using snapshot-based drawing."""
-        # Call parent implementation first
-        Gtk.Widget.do_snapshot(self, snapshot)
+        # Draw focus rectangle
+        if self.has_focus():
+            width = self.get_width()
+            height = self.get_height()
+            rect = Graphene.Rect()
+            rect.init(0, 0, width, height)
+
+            color = Gdk.RGBA()
+            color.parse(style.COLOR_BUTTON_GREY.get_svg())
+            snapshot.append_color(color, rect)
+
+        # Snapshot child
+        child = self.get_first_child()
+        while child is not None:
+            self.snapshot_child(child, snapshot)
+            child = child.get_next_sibling()
 
         palette = self.get_palette()
         if palette and palette.is_up():

--- a/src/sugar4/graphics/toolbutton.py
+++ b/src/sugar4/graphics/toolbutton.py
@@ -134,6 +134,7 @@ class ToolButton(Gtk.Button):
 
         # button styling for toolbar appearance
         self.add_css_class("toolbar-button")
+        self.add_css_class("flat")
         self.set_has_frame(False)
         self.set_can_focus(True)
 
@@ -172,17 +173,17 @@ class ToolButton(Gtk.Button):
         }
 
         .toolbar-button:hover {
-            background: alpha(@theme_fg_color, 0.1);
+            background: alpha(currentColor, 0.1);
         }
 
         .toolbar-button:active,
         .toolbar-button.active {
-            background: alpha(@theme_fg_color, 0.2);
-            border: 1px solid alpha(@theme_fg_color, 0.3);
+            background: alpha(currentColor, 0.2);
+            border: 1px solid alpha(currentColor, 0.3);
         }
 
         .toolbar-button:focus {
-            outline: 2px solid @theme_selected_bg_color;
+            outline: 2px solid rgb(53, 132, 228);
             outline-offset: 2px;
         }
         """
@@ -417,50 +418,7 @@ class ToolButton(Gtk.Button):
         blurb="Invoker for the palette",
     )
 
-    def do_snapshot(self, snapshot):
-        """Render tool button using snapshot-based drawing."""
-        # Draw focus rectangle
-        if self.has_focus():
-            width = self.get_width()
-            height = self.get_height()
-            rect = Graphene.Rect()
-            rect.init(0, 0, width, height)
 
-            color = Gdk.RGBA()
-            color.parse(style.COLOR_BUTTON_GREY.get_svg())
-            snapshot.append_color(color, rect)
-
-        # Snapshot child
-        child = self.get_first_child()
-        while child is not None:
-            self.snapshot_child(child, snapshot)
-            child = child.get_next_sibling()
-
-        palette = self.get_palette()
-        if palette and palette.is_up():
-            # Get button allocation
-            width = self.get_width()
-            height = self.get_height()
-
-            if width > 0 and height > 0:
-                # Draw active state border
-                color = Gdk.RGBA()
-                color.red = 0.0
-                color.green = 0.5
-                color.blue = 1.0
-                color.alpha = 0.8
-
-                rect = Graphene.Rect()
-                rect.init(0, 0, width, height)
-                rounded = Gsk.RoundedRect()
-                rounded.init_from_rect(rect, 6.0)
-
-                # Draw border
-                snapshot.append_border(
-                    rounded,
-                    [2, 2, 2, 2],  # border widths
-                    [color, color, color, color],  # border colors
-                )
 
     def set_active(self, active: bool):
         if active:
@@ -493,7 +451,7 @@ def _apply_module_css():
 
     /* Active palette indicator */
     .toolbar-button.active {
-        box-shadow: inset 0 0 0 2px @theme_selected_bg_color;
+        box-shadow: inset 0 0 0 2px rgb(53, 132, 228);
     }
     """
 

--- a/src/sugar4/graphics/toolbutton.py
+++ b/src/sugar4/graphics/toolbutton.py
@@ -154,48 +154,13 @@ class ToolButton(Gtk.Button):
         if self._accelerator:
             self.set_accelerator(self._accelerator)
 
-        self.connect("unrealize", self.__destroy_cb)
         self.connect("clicked", self.__clicked_cb)
 
-        self._apply_toolbar_button_css()
-
-    def _apply_toolbar_button_css(self):
-        css = """
-        .toolbar-button {
-            border-radius: 6px;
-            margin: 2px;
-            padding: 6px;
-            min-width: 32px;
-            min-height: 32px;
-        }
-
-        .toolbar-button:hover {
-            background: alpha(currentColor, 0.1);
-        }
-
-        .toolbar-button:active,
-        .toolbar-button.active {
-            background: alpha(currentColor, 0.2);
-            border: 1px solid alpha(currentColor, 0.3);
-        }
-
-        .toolbar-button:focus {
-            outline: 2px solid rgb(53, 132, 228);
-            outline-offset: 2px;
-        }
-        """
-
-        try:
-            css_provider = Gtk.CssProvider()
-            css_provider.load_from_string(css)
-            self.get_style_context().add_provider(css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
-        except Exception as e:
-            logging.warning(f"Could not apply toolbar button CSS: {e}")
-
-    def __destroy_cb(self, widget):
-        if self._palette_invoker is not None:
+    def do_dispose(self):
+        if getattr(self, "_palette_invoker", None) is not None:
             self._palette_invoker.detach()
             self._palette_invoker = None
+        super().do_dispose()
 
     def __clicked_cb(self, button):
         if self._hide_tooltip_on_click and self.get_palette():
@@ -295,24 +260,17 @@ class ToolButton(Gtk.Button):
     )
 
     def set_icon_name(self, icon_name: Optional[str]):
-        print(f"[ToolButton] set_icon_name called with: {icon_name}")
         if self._icon_widget:
             self._content_box.remove(self._icon_widget)
             self._icon_widget = None
         if icon_name:
-            import os
-
             if os.path.isabs(icon_name) or icon_name.endswith(
                 (".svg", ".png", ".jpg", ".jpeg")
             ):
-                print(
-                    f"[ToolButton] Icon file exists: {os.path.exists(icon_name)} at {icon_name}"
-                )
                 self._icon_widget = Icon(
                     file_name=icon_name, pixel_size=style.STANDARD_ICON_SIZE
                 )
             else:
-                print(f"[ToolButton] Using icon name: {icon_name}")
                 self._icon_widget = Icon(
                     icon_name=icon_name, pixel_size=style.STANDARD_ICON_SIZE
                 )

--- a/src/sugar4/graphics/toolbutton.py
+++ b/src/sugar4/graphics/toolbutton.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2007, Red Hat, Inc.
+﻿# Copyright (C) 2007, Red Hat, Inc.
 # Copyright (C) 2008, One Laptop Per Child
 # Copyright (C) 2025 MostlyK
 #
@@ -76,10 +76,8 @@ def _add_accelerator(tool_button):
     if not root:
         return
 
-    # GTK4: Use application shortcuts instead of AccelGroup
     app = root.get_application() if hasattr(root, "get_application") else None
     if app and hasattr(app, "set_accels_for_action"):
-        # Create a unique action name for this button
         action_name = f"toolbutton.{id(tool_button)}"
 
         # Add the action to trigger the button click
@@ -104,7 +102,6 @@ def _hierarchy_changed_cb(tool_button):
 
 def setup_accelerator(tool_button):
     _add_accelerator(tool_button)
-    # GTK4: Connect to root notify signal since hierarchy-changed doesn't exist
     if hasattr(tool_button, "connect"):
         tool_button.connect(
             "notify::root", lambda *args: _hierarchy_changed_cb(tool_button)

--- a/src/sugar4/graphics/toolbutton.py
+++ b/src/sugar4/graphics/toolbutton.py
@@ -1,4 +1,4 @@
-﻿# Copyright (C) 2007, Red Hat, Inc.
+# Copyright (C) 2007, Red Hat, Inc.
 # Copyright (C) 2008, One Laptop Per Child
 # Copyright (C) 2025 MostlyK
 #
@@ -154,7 +154,7 @@ class ToolButton(Gtk.Button):
         if self._accelerator:
             self.set_accelerator(self._accelerator)
 
-        self.connect("destroy", self.__destroy_cb)
+        self.connect("unrealize", self.__destroy_cb)
         self.connect("clicked", self.__clicked_cb)
 
         self._apply_toolbar_button_css()
@@ -198,17 +198,13 @@ class ToolButton(Gtk.Button):
             self._palette_invoker = None
 
     def __clicked_cb(self, button):
-        print(f"ToolButton.__clicked_cb: 'clicked' signal received for {button}")
-        # Hide tooltip if needed
         if self._hide_tooltip_on_click and self.get_palette():
             palette = self.get_palette()
             if palette is not None:
                 if palette.is_up():
                     palette.popdown(immediate=True)
-        # Explicitly trigger palette invoker toggle if present
         invoker = self.get_palette_invoker()
         if invoker and getattr(invoker, "_toggle_palette", False):
-            print("ToolButton.__clicked_cb: calling invoker.notify_toggle_state()")
             invoker.notify_toggle_state()
 
     def set_tooltip(self, tooltip: Optional[str]):

--- a/src/sugar4/graphics/tray.py
+++ b/src/sugar4/graphics/tray.py
@@ -106,17 +106,22 @@ class _TrayViewport(Gtk.ScrolledWindow):
             logging.warning("Item not found in tray children")
             return
 
-        allocation = item.get_allocation()
         if self.orientation == Gtk.Orientation.HORIZONTAL:
             adj = self.get_hadjustment()
-            start = allocation.x
-            stop = allocation.x + allocation.width
+            # Translate item position relative to traybar
+            ok, x, _ = item.translate_coordinates(self.traybar, 0, 0)
+            if not ok:
+                return
+            start = x
+            stop = x + item.get_width()
         else:
             adj = self.get_vadjustment()
-            start = allocation.y
-            stop = allocation.y + allocation.height
+            ok, _, y = item.translate_coordinates(self.traybar, 0, 0)
+            if not ok:
+                return
+            start = y
+            stop = y + item.get_height()
 
-        # Scroll if needed
         if start < adj.get_value():
             adj.set_value(start)
         elif stop > adj.get_value() + adj.get_page_size():
@@ -124,26 +129,28 @@ class _TrayViewport(Gtk.ScrolledWindow):
 
     def _scroll_next(self):
         """Scroll to next page."""
-        allocation = self.get_allocation()
+        width = self.get_width()
+        height = self.get_height()
         if self.orientation == Gtk.Orientation.HORIZONTAL:
             adj = self.get_hadjustment()
-            new_value = adj.get_value() + allocation.width
-            adj.set_value(min(new_value, adj.get_upper() - allocation.width))
+            new_value = adj.get_value() + width
+            adj.set_value(min(new_value, adj.get_upper() - width))
         else:
             adj = self.get_vadjustment()
-            new_value = adj.get_value() + allocation.height
-            adj.set_value(min(new_value, adj.get_upper() - allocation.height))
+            new_value = adj.get_value() + height
+            adj.set_value(min(new_value, adj.get_upper() - height))
 
     def _scroll_previous(self):
         """Scroll to previous page."""
-        allocation = self.get_allocation()
+        width = self.get_width()
+        height = self.get_height()
         if self.orientation == Gtk.Orientation.HORIZONTAL:
             adj = self.get_hadjustment()
-            new_value = adj.get_value() - allocation.width
+            new_value = adj.get_value() - width
             adj.set_value(max(adj.get_lower(), new_value))
         else:
             adj = self.get_vadjustment()
-            new_value = adj.get_value() - allocation.height
+            new_value = adj.get_value() - height
             adj.set_value(max(adj.get_lower(), new_value))
 
 
@@ -160,17 +167,18 @@ class _TrayViewport(Gtk.ScrolledWindow):
         self._update_scrollable_state()
 
     def _update_scrollable_state(self):
-        allocation = self.get_allocation()
-        if allocation.width <= 1 and allocation.height <= 1:
+        width = self.get_width()
+        height = self.get_height()
+        if width <= 1 and height <= 1:
             return
 
-        min_w, nat_w, _, _ = self.traybar.measure(Gtk.Orientation.HORIZONTAL, -1)
-        min_h, nat_h, _, _ = self.traybar.measure(Gtk.Orientation.VERTICAL, -1)
+        _min_w, nat_w, _, _ = self.traybar.measure(Gtk.Orientation.HORIZONTAL, -1)
+        _min_h, nat_h, _, _ = self.traybar.measure(Gtk.Orientation.VERTICAL, -1)
 
         if self.orientation == Gtk.Orientation.HORIZONTAL:
-            scrollable = nat_w > allocation.width
+            scrollable = nat_w > width
         else:
-            scrollable = nat_h > allocation.height
+            scrollable = nat_h > height
 
         if scrollable != self._scrollable:
             self._scrollable = scrollable
@@ -210,11 +218,11 @@ class _TrayViewport(Gtk.ScrolledWindow):
         if index == -1:
             self.traybar.append(item)
         else:
-            # GTK4 doesn't have direct index insertion, so we use reorder
             self.traybar.append(item)
-            if index < len(self.get_children()) - 1:
+            children = self.get_children()
+            if index < len(children) - 1:
                 self.traybar.reorder_child_after(
-                    item, self.get_children()[index - 1] if index > 0 else None
+                    item, children[index - 1] if index > 0 else None
                 )
 
     def remove_item(self, item):
@@ -335,7 +343,7 @@ class HTray(Gtk.Widget):
         """Clean up widget on disposal."""
         if self._box:
             self._box.unparent()
-        ## TODO: well could be a bug
+            self._box = None
         super().do_dispose()
 
     def do_measure(self, orientation, for_size):
@@ -448,7 +456,7 @@ class VTray(Gtk.Widget):
         """Clean up widget on disposal."""
         if self._box:
             self._box.unparent()
-        ## TODO: well could be a bug
+            self._box = None
         super().do_dispose()
 
     def do_measure(self, orientation, for_size):
@@ -571,20 +579,10 @@ class TrayIcon(ToolButton):
         return self.get_icon_widget()
 
 
-def _apply_tray_css():
-    """Apply CSS styling for tray widgets."""
-    css = """
-    .drag-active {
-        background-color: rgba(0, 0, 0, 0.2);
-    }
-    """
-    style.apply_css_to_widget(None, css)  # Apply globally
-
-
 try:
     _apply_tray_css()
 except Exception:
-    pass  # Ignore if GTK is not available
+    pass
 
 
 if hasattr(HTray, "set_css_name"):

--- a/src/sugar4/graphics/tray.py
+++ b/src/sugar4/graphics/tray.py
@@ -138,19 +138,7 @@ class _TrayViewport(Gtk.ScrolledWindow):
             new_value = adj.get_value() - allocation.height
             adj.set_value(max(adj.get_lower(), new_value))
 
-    def do_get_preferred_width(self):
-        if self.orientation == Gtk.Orientation.HORIZONTAL:
-            return 0, -1  # Minimum 0, natural unlimited
-        else:
-            child_min, child_nat = self.traybar.get_preferred_size()
-            return child_min.width, child_nat.width
 
-    def do_get_preferred_height(self):
-        if self.orientation == Gtk.Orientation.VERTICAL:
-            return 0, -1  # Minimum 0, natural unlimited
-        else:
-            child_min, child_nat = self.traybar.get_preferred_size()
-            return child_min.height, child_nat.height
 
     def do_get_property(self, pspec):
         if pspec.name == "scrollable":
@@ -168,12 +156,13 @@ class _TrayViewport(Gtk.ScrolledWindow):
         if allocation.width <= 1 and allocation.height <= 1:
             return
 
-        traybar_min, traybar_nat = self.traybar.get_preferred_size()
+        min_w, nat_w, _, _ = self.traybar.measure(Gtk.Orientation.HORIZONTAL, -1)
+        min_h, nat_h, _, _ = self.traybar.measure(Gtk.Orientation.VERTICAL, -1)
 
         if self.orientation == Gtk.Orientation.HORIZONTAL:
-            scrollable = traybar_nat.width > allocation.width
+            scrollable = nat_w > allocation.width
         else:
-            scrollable = traybar_nat.height > allocation.height
+            scrollable = nat_h > allocation.height
 
         if scrollable != self._scrollable:
             self._scrollable = scrollable
@@ -263,6 +252,9 @@ class _TrayScrollButton(ToolButton):
             )
             self.set_sensitive(self._viewport.props.can_scroll_next)
 
+        # Initialize visibility correctly based on current state
+        self.set_visible(self._viewport.props.scrollable)
+
     def _viewport_scrollable_changed_cb(self, viewport, pspec):
         """Handle viewport scrollable state changes."""
         self.set_visible(self._viewport.props.scrollable)
@@ -345,6 +337,10 @@ class HTray(Gtk.Widget):
 
     def do_size_allocate(self, width, height, baseline):
         self._box.allocate(width, height, baseline, None)
+
+    def do_snapshot(self, snapshot):
+        if self._box:
+            self.snapshot_child(self._box, snapshot)
 
     def do_set_property(self, pspec, value):
         if pspec.name == "align":
@@ -468,6 +464,11 @@ class VTray(Gtk.Widget):
         """Allocate size to child widgets."""
         self._box.allocate(width, height, baseline, None)
 
+    def do_snapshot(self, snapshot):
+        """Render widget."""
+        if self._box:
+            self.snapshot_child(self._box, snapshot)
+
     def do_set_property(self, pspec, value):
         """Set property values."""
         if pspec.name == "align":
@@ -539,165 +540,37 @@ class VTray(Gtk.Widget):
 class TrayButton(ToolButton):
     """A button for use in trays."""
 
+    __gtype_name__ = "SugarTrayButton"
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
 
-class _IconWidget(Gtk.Widget):
-    """Widget for displaying tray icons."""
-
-    __gtype_name__ = "SugarTrayIconWidget"
-
-    def __init__(self, icon_name=None, xo_color=None):
-        super().__init__()
-
-        self._box = Gtk.Box()
-        self._box.set_parent(self)
-
-        self._icon = Icon(pixel_size=style.STANDARD_ICON_SIZE)
-        if icon_name is not None:
-            self.set_icon_name(icon_name)
-        if xo_color is not None:
-            self._icon.set_xo_color(xo_color)
-        self._box.append(self._icon)
-
-        click_gesture = Gtk.GestureClick()
-        click_gesture.connect("pressed", self._on_button_press)
-        click_gesture.connect("released", self._on_button_release)
-        self.add_controller(click_gesture)
-
-    def set_icon_name(self, icon_name):
-        # If icon_name is a path to a file, use it as file_name
-        import os
-
-        if icon_name and isinstance(icon_name, str) and os.path.isfile(icon_name):
-            self._icon.set_file_name(icon_name)
-            self._icon.set_icon_name(None)
-        else:
-            self._icon.set_icon_name(icon_name)
-            self._icon.set_file_name(None)
-
-    def get_icon_name(self):
-        # Prefer icon_name, but if not set, return file_name
-        name = self._icon.get_icon_name()
-        if name:
-            return name
-        return self._icon.get_file_name()
-
-    def do_dispose(self):
-        """Clean up widget on disposal."""
-        if self._box:
-            self._box.unparent()
-        ## TODO: Might be a bug
-        super().do_dispose()
-
-    def do_measure(self, orientation, for_size):
-        return self._box.measure(orientation, for_size)
-
-    def do_size_allocate(self, width, height, baseline):
-        self._box.allocate(width, height, baseline, None)
-
-    def do_snapshot(self, snapshot):
-        """Render widget using snapshot-based drawing."""
-        palette = (
-            self.get_parent().palette if hasattr(self.get_parent(), "palette") else None
-        )
-
-        if palette and palette.is_up():
-            width = self.get_width()
-            height = self.get_height()
-
-            # Use snapshot API for drawing background
-            color = Gdk.RGBA()
-            color.parse("#000000")
-            snapshot.append_color(color, Graphene.Rect().init(0, 0, width, height))
-
-        # Draw the child widget
-        self.snapshot_child(self._box, snapshot)
-
-    def _on_button_press(self, gesture, n_press, x, y):
-        pass
-
-    def _on_button_release(self, gesture, n_press, x, y):
-        pass
-
-    def get_icon(self):
-        return self._icon
-
-    def set_xo_color(self, xo_color):
-        self._icon.set_xo_color(xo_color)
-
-    def get_xo_color(self):
-        return self._icon.get_xo_color()
-
-
-class TrayIcon(Gtk.Button):
+class TrayIcon(ToolButton):
     """An icon for use in trays with palette support."""
 
     __gtype_name__ = "SugarTrayIcon"
 
     def __init__(self, icon_name=None, xo_color=None):
-        super().__init__()
+        super().__init__(icon_name=icon_name)
 
-        self._icon_widget = _IconWidget()
-        if icon_name is not None:
-            self.set_icon_name(icon_name)
         if xo_color is not None:
             self.set_xo_color(xo_color)
-        self.set_child(self._icon_widget)
 
         self._palette_invoker = ToolInvoker(self)
 
         self.set_size_request(style.GRID_CELL_SIZE, style.GRID_CELL_SIZE)
 
-        self.connect("destroy", self.__destroy_cb)
-
-    def __destroy_cb(self, icon):
-        """Clean up on destruction."""
-        if self._palette_invoker is not None:
-            self._palette_invoker.detach()
-
-    def create_palette(self):
-        """Create palette - override in subclasses."""
+    def get_xo_color(self):
+        icon_widget = self.get_icon_widget()
+        if icon_widget and hasattr(icon_widget, 'get_xo_color'):
+            return icon_widget.get_xo_color()
         return None
 
-    def get_palette(self):
-        return self._palette_invoker.palette
-
-    def set_palette(self, palette):
-        self._palette_invoker.palette = palette
-
-    palette = GObject.Property(type=object, setter=set_palette, getter=get_palette)
-
-    def get_palette_invoker(self):
-        """Get the palette invoker."""
-        return self._palette_invoker
-
-    def set_palette_invoker(self, palette_invoker):
-        """Set the palette invoker."""
-        self._palette_invoker.detach()
-        self._palette_invoker = palette_invoker
-
-    palette_invoker = GObject.Property(
-        type=object, setter=set_palette_invoker, getter=get_palette_invoker
-    )
-
-    def get_icon(self):
-        return self._icon_widget.get_icon()
-
-    def get_icon_name(self):
-        return self._icon_widget.get_icon_name()
-
-    def set_icon_name(self, icon_name):
-        self._icon_widget.set_icon_name(icon_name)
-
-    def get_xo_color(self):
-        return self._icon_widget.get_xo_color()
-
     def set_xo_color(self, xo_color):
-        self._icon_widget.set_xo_color(xo_color)
-
-    icon = property(get_icon, None)
+        icon_widget = self.get_icon_widget()
+        if icon_widget and hasattr(icon_widget, 'set_xo_color'):
+            icon_widget.set_xo_color(xo_color)
 
 
 def _apply_tray_css():

--- a/src/sugar4/graphics/tray.py
+++ b/src/sugar4/graphics/tray.py
@@ -73,6 +73,13 @@ class _TrayViewport(Gtk.ScrolledWindow):
             self.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
 
         self.set_has_frame(False)
+        self.set_propagate_natural_height(False)
+        self.set_propagate_natural_width(False)
+
+        if self.orientation == Gtk.Orientation.HORIZONTAL:
+            self.set_min_content_height(GRID_CELL_SIZE)
+        else:
+            self.set_min_content_width(GRID_CELL_SIZE)
 
         # using Box instead of Toolbar for GTK4
         self.traybar = Gtk.Box(orientation=orientation)

--- a/src/sugar4/graphics/tray.py
+++ b/src/sugar4/graphics/tray.py
@@ -572,6 +572,10 @@ class TrayIcon(ToolButton):
         if icon_widget and hasattr(icon_widget, 'set_xo_color'):
             icon_widget.set_xo_color(xo_color)
 
+    @property
+    def icon(self):
+        return self.get_icon_widget()
+
 
 def _apply_tray_css():
     """Apply CSS styling for tray widgets."""

--- a/src/sugar4/graphics/tray.py
+++ b/src/sugar4/graphics/tray.py
@@ -72,6 +72,8 @@ class _TrayViewport(Gtk.ScrolledWindow):
         else:
             self.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
 
+        self.set_has_frame(False)
+
         # using Box instead of Toolbar for GTK4
         self.traybar = Gtk.Box(orientation=orientation)
         self.traybar.set_homogeneous(False)
@@ -97,7 +99,6 @@ class _TrayViewport(Gtk.ScrolledWindow):
             logging.warning("Item not found in tray children")
             return
 
-        # Get the item's allocation
         allocation = item.get_allocation()
         if self.orientation == Gtk.Orientation.HORIZONTAL:
             adj = self.get_hadjustment()
@@ -225,6 +226,7 @@ class _TrayScrollButton(ToolButton):
         self._viewport = None
         self._scroll_direction = scroll_direction
 
+        self.add_css_class("tray-button")
         self.set_size_request(style.GRID_CELL_SIZE, style.GRID_CELL_SIZE)
 
         self.icon = Icon(icon_name=icon_name, pixel_size=style.SMALL_ICON_SIZE)
@@ -252,7 +254,6 @@ class _TrayScrollButton(ToolButton):
             )
             self.set_sensitive(self._viewport.props.can_scroll_next)
 
-        # Initialize visibility correctly based on current state
         self.set_visible(self._viewport.props.scrollable)
 
     def _viewport_scrollable_changed_cb(self, viewport, pspec):
@@ -321,9 +322,7 @@ class HTray(Gtk.Widget):
         scroll_right.viewport = self._viewport
 
         if self.align == ALIGN_TO_END:
-            spacer = Gtk.Box()
-            spacer.set_hexpand(True)
-            self._viewport.add_item(spacer, 0)
+            self._viewport.set_halign(Gtk.Align.END)
 
     def do_dispose(self):
         """Clean up widget on disposal."""
@@ -362,7 +361,6 @@ class HTray(Gtk.Widget):
         if self._drag_active != active:
             self._drag_active = active
             if self._drag_active:
-                # GTK4: Use CSS for background color changes
                 self._viewport.add_css_class("drag-active")
             else:
                 self._viewport.remove_css_class("drag-active")
@@ -374,14 +372,9 @@ class HTray(Gtk.Widget):
         self._set_drag_active(active)
 
     def get_children(self):
-        children = self._viewport.get_children()
-        if self.align == ALIGN_TO_END and children:
-            return children[1:]  # Skip spacer
-        return children
+        return self._viewport.get_children()
 
     def add_item(self, item, index=-1):
-        if self.align == ALIGN_TO_END and index > -1:
-            index += 1  # Account for spacer
         self._viewport.add_item(item, index)
 
     def remove_item(self, item):
@@ -391,10 +384,7 @@ class HTray(Gtk.Widget):
         """Get index of item in tray."""
         children = self._viewport.get_children()
         try:
-            index = children.index(item)
-            if self.align == ALIGN_TO_END:
-                index -= 1  # Account for spacer
-            return index
+            return children.index(item)
         except ValueError:
             return -1
 
@@ -445,9 +435,7 @@ class VTray(Gtk.Widget):
         scroll_down.viewport = self._viewport
 
         if self.align == ALIGN_TO_END:
-            spacer = Gtk.Box()
-            spacer.set_vexpand(True)
-            self._viewport.add_item(spacer, 0)
+            self._viewport.set_valign(Gtk.Align.END)
 
     def do_dispose(self):
         """Clean up widget on disposal."""
@@ -506,15 +494,10 @@ class VTray(Gtk.Widget):
 
     def get_children(self):
         """Get tray children."""
-        children = self._viewport.get_children()
-        if self.align == ALIGN_TO_END and children:
-            return children[1:]  # Skip spacer
-        return children
+        return self._viewport.get_children()
 
     def add_item(self, item, index=-1):
         """Add item to tray."""
-        if self.align == ALIGN_TO_END and index > -1:
-            index += 1  # Account for spacer
         self._viewport.add_item(item, index)
 
     def remove_item(self, item):
@@ -525,10 +508,7 @@ class VTray(Gtk.Widget):
         """Get index of item in tray."""
         children = self._viewport.get_children()
         try:
-            index = children.index(item)
-            if self.align == ALIGN_TO_END:
-                index -= 1  # Account for spacer
-            return index
+            return children.index(item)
         except ValueError:
             return -1
 
@@ -544,6 +524,8 @@ class TrayButton(ToolButton):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.add_css_class("tray-button")
+        self.set_size_request(style.GRID_CELL_SIZE, style.GRID_CELL_SIZE)
 
 
 class TrayIcon(ToolButton):
@@ -553,6 +535,8 @@ class TrayIcon(ToolButton):
 
     def __init__(self, icon_name=None, xo_color=None):
         super().__init__(icon_name=icon_name)
+
+        self.add_css_class("tray-button")
 
         if xo_color is not None:
             self.set_xo_color(xo_color)

--- a/src/sugar4/graphics/tray.py
+++ b/src/sugar4/graphics/tray.py
@@ -108,17 +108,18 @@ class _TrayViewport(Gtk.ScrolledWindow):
 
         if self.orientation == Gtk.Orientation.HORIZONTAL:
             adj = self.get_hadjustment()
-            # Translate item position relative to traybar
-            ok, x, _ = item.translate_coordinates(self.traybar, 0, 0)
-            if not ok:
+            coords = item.translate_coordinates(self.traybar, 0, 0)
+            if not coords:
                 return
+            x = coords[0]
             start = x
             stop = x + item.get_width()
         else:
             adj = self.get_vadjustment()
-            ok, _, y = item.translate_coordinates(self.traybar, 0, 0)
-            if not ok:
+            coords = item.translate_coordinates(self.traybar, 0, 0)
+            if not coords:
                 return
+            y = coords[1]
             start = y
             stop = y + item.get_height()
 

--- a/src/sugar4/graphics/tray.py
+++ b/src/sugar4/graphics/tray.py
@@ -556,6 +556,9 @@ class TrayIcon(ToolButton):
 
         if xo_color is not None:
             self.set_xo_color(xo_color)
+        else:
+            self.icon.props.stroke_color = style.COLOR_WHITE.get_svg()
+            self.icon.props.fill_color = style.COLOR_TRANSPARENT.get_svg()
 
         self._palette_invoker = ToolInvoker(self)
 

--- a/src/sugar4/graphics/window.py
+++ b/src/sugar4/graphics/window.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2007, Red Hat, Inc.
+﻿# Copyright (C) 2007, Red Hat, Inc.
 # Copyright (C) 2009, Aleksey Lim, Sayamindu Dasgupta
 # Copyright (C) 2025 MostlyK
 #
@@ -109,7 +109,6 @@ class UnfullscreenButton(Gtk.Window):
             geometry = monitor.get_geometry()
             x = geometry.x + geometry.width - self._width
             y = geometry.y
-            # Note: GTK4 window positioning is more limited
             # We rely on window manager for positioning
 
     def _on_monitors_changed(self, display):

--- a/src/sugar4/profile.py
+++ b/src/sugar4/profile.py
@@ -88,12 +88,12 @@ class Profile(object):
             logging.exception("Error reading public key")
             return None
 
-        magic = "ssh-dss "
+        magics = ("ssh-dss ", "ssh-rsa ", "ssh-ed25519 ")
         for line in lines:
             line = line.strip()
-            if not line.startswith(magic):
-                continue
-            return line[len(magic) :]
+            for magic in magics:
+                if line.startswith(magic):
+                    return line[len(magic) :]
         else:
             logging.error("Error parsing public key.")
             return None
@@ -120,13 +120,18 @@ class Profile(object):
             if line.startswith(
                 (
                     "-----BEGIN DSA PRIVATE KEY-----",
+                    "-----BEGIN RSA PRIVATE KEY-----",
                     "-----BEGIN OPENSSH PRIVATE KEY-----",
                 )
             ):
                 begin_found = True
                 continue
             if line.startswith(
-                ("-----END DSA PRIVATE KEY-----", "-----END OPENSSH PRIVATE KEY-----")
+                (
+                    "-----END DSA PRIVATE KEY-----",
+                    "-----END RSA PRIVATE KEY-----",
+                    "-----END OPENSSH PRIVATE KEY-----",
+                )
             ):
                 end_found = True
                 continue


### PR DESCRIPTION
This PR introduces widget implementations, rendering stability improvements, and event-handling fixes in `sugar-toolkit-gtk4` to support the migration of the Sugar desktop environment to GTK4.

### Key Changes:

#### 1. Graphics & Layout Stability
- **Gtk.Snapshot Migration (`icon.py`):** Replaced legacy paint methods with modern snapshot-based drawing (`do_snapshot`) for proper resource scaling and caching.
- **Alert & Tray Layouts (`alert.py`, `tray.py`):** Ported legacy layout packing and alignment to standard GTK4 box packing models, suppressing container-related layout warnings.
- **Window Hierarchy & Modals (`window.py`, `objectchooser.py`):** Configured transient window models for dialogs and chooser dialogs to respect window manager focus policies.

#### 2. Palette & Popover Interactions (`palettewindow.py`, `palettemenu.py`)
- **Pointer-Tracking Autohide:** Implemented a non-blocking pointer-tracking timer (`_check_mouse_outside`) in `PaletteWindow` that periodically checks if the cursor has left both the invoker and popover allocations to trigger dismissal. This resolves the grab-inhibited event propagation issues inherent to `Gtk.Popover` in GTK4.
- **Auto-dismissal on Activation:** Added recursive parent widget traversal to `PaletteMenuItem` activation callbacks to automatically locate and dismiss (`popdown()`) the parent `Gtk.Popover`.
- **Parent Management:** Cleaned up PyGObject parent widget binding logic (`Gtk.Widget.set_parent`) to avoid partial-root state assertion errors.

#### 3. Event Handling & Input Cleanup
- **Controller Lifecycle (`palettewindow.py`):** Wrapped controller removal operations in safe `try/except` blocks to prevent crash scenarios on widget destruction during input events.
- **TreeView Single-Click (`palettewindow.py`):** Standardized TreeView cell renderer activation coordinates and path conversions to ensure click-handler reliability.