### PR TITLE
Fix GTK4 shell integration bugs

### DIFF
--- a/src/sugar4/activity/activity.py
+++ b/src/sugar4/activity/activity.py
@@ -1023,8 +1023,8 @@ class Activity(Window):
 
         preview = self.get_preview()
         if preview is not None:
-            # In GTK4, we handle binary data differently
-            self.metadata["preview"] = preview
+            # Wrap in ByteArray to ensure DBus marshals the binary data correctly
+            self.metadata["preview"] = dbus.ByteArray(preview)
 
         if not self.metadata.get("activity_id", ""):
             self.metadata["activity_id"] = self.get_id()
@@ -1479,7 +1479,7 @@ class Activity(Window):
         """
         self._busy_count -= 1
         if self._busy_count == 0:
-            self.set_cursor(None)
+            self.set_cursor(Gdk.Cursor.new_from_name("default", None))
         return self._busy_count
 
 

--- a/src/sugar4/activity/activityinstance.py
+++ b/src/sugar4/activity/activityinstance.py
@@ -217,4 +217,4 @@ def main():
         module.start()
 
     # Run the GTK application
-    sys.exit(app.run(sys.argv))
+    sys.exit(app.run([sys.argv[0]]))

--- a/src/sugar4/graphics/toolbarbox.py
+++ b/src/sugar4/graphics/toolbarbox.py
@@ -120,7 +120,7 @@ class ToolbarButton(ToolButton):
         )
 
     def is_expanded(self):
-        return self.page is not None and not self.is_in_palette()
+        return getattr(self, '_expanded', False)
 
     def popdown(self):
         palette = self.get_palette()
@@ -151,6 +151,7 @@ class ToolbarButton(ToolButton):
         self._unparent()
         _setup_page(self.page_widget, style.COLOR_TOOLBAR_GREY, box.get_padding())
         box.append(self.page_widget)
+        self.page_widget.set_visible(True)
 
         self._expanded = True
         self.add_css_class("expanded")
@@ -477,8 +478,12 @@ def _setup_page(page_widget, color, hpad):
 
     page = _get_embedded_page(page_widget)
     if page:
+        # Give this specific widget a unique class to scope the global CSS provider
+        cls_name = f"toolbar-page-{id(page)}"
+        page.add_css_class(cls_name)
+        
         css = f"""
-        * {{
+        .{cls_name} {{
             background: {color.get_css_rgba()};
         }}
         """


### PR DESCRIPTION
This PR fixes a few regressions and crashes that showed up while testing activities in the GTK4 Sugar Shell.

* **Application launch crash:** `Gtk.Application` was trying to parse the command-line arguments passed by the Sugar Shell (such as `-s` and `-b`), which caused activities to crash on startup. We now pass only the script name so GTK doesn't try to parse the shell-specific arguments.
* **Datastore save crash:** Fixed a regression where binary image data was sent directly over DBus instead of being wrapped in a `dbus.ByteArray`. This removes the `ValueError: embedded null byte` error and allows activities to save correctly to the Journal on exit.
* **CSS leaking across the shell:** A `Gtk.CssProvider` containing `* { background: ... }` was being applied globally in GTK4, affecting the entire Sugar Shell and causing rendering issues, including black screens. The CSS is now applied only to the intended widget.
* **Cursor initialization:** Initializing the cursor with `None` during the `unbusy` state caused a `TypeError` in GTK4. This has been replaced with a properly initialized default `Gdk.Cursor`.
